### PR TITLE
[CarPlay] New Feature - Update tabbar templates

### DIFF
--- a/ios/Classes/FCPEnums.swift
+++ b/ios/Classes/FCPEnums.swift
@@ -16,6 +16,7 @@ enum FCPChannelTypes {
   static let setRootTemplate = "setRootTemplate"
   static let forceUpdateRootTemplate = "forceUpdateRootTemplate"
   static let updateListTemplateSections = "updateListTemplateSections"
+  static let updateTabBarTemplates = "updateTabBarTemplates"
   static let updateListItem = "updateListItem"
   static let onListItemSelected = "onFCPListItemSelected"
   static let onListItemSelectedComplete = "onFCPListItemSelectedComplete"

--- a/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
+++ b/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
@@ -31,6 +31,7 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     self.interfaceController?.setRootTemplate(rootTemplate!, animated: animated)
   }
 
+  // https://developer.apple.com/documentation/carplay/cplisttemplate/updatesections(_:)
   static public func updateListTemplateSections(elementId: String, sections: [FCPListSection]) {
     guard let interfaceController = self.interfaceController else { return }
 
@@ -47,6 +48,24 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
 
     templateFromHistory.updateSections(sections: sections)
     template.updateSections(templateFromHistory.getRawSections())
+  }
+
+  // https://developer.apple.com/documentation/carplay/cptabbartemplate/updatetemplates(_:)
+  static public func updateTabBarTemplates(elementId: String, templates: [FCPListTemplate]) {
+    guard let interfaceController = self.interfaceController else { return }
+
+    guard let template = interfaceController.templates.first(where: { $0.elementId == elementId }) as? CPTabBarTemplate else {
+        NSLog("FlutterCarPlaySceneDelegate - updateTabBarTemplates: TabBar template with elementId \(elementId) not found.")
+        return
+    }
+
+    guard let templateFromHistory = SwiftFlutterCarplayPlugin.getTemplateFromHistory(elementId: elementId) as? FCPTabBarTemplate  else {
+        NSLog("FlutterCarPlaySceneDelegate - updateTabBarTemplates: TabBar template from history with elementId \(elementId) not found.")
+        return
+    }
+
+    templateFromHistory.updateTemplates(templates: templates)
+    template.updateTemplates(templateFromHistory.getRawTemplates())
   }
 
   // Fired when just before the carplay become active

--- a/ios/Classes/SwiftFlutterCarplayPlugin.swift
+++ b/ios/Classes/SwiftFlutterCarplayPlugin.swift
@@ -104,6 +104,18 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       FlutterCarPlaySceneDelegate.updateListTemplateSections(elementId: elementId, sections: sections)
       result(true)
       break
+    case FCPChannelTypes.updateTabBarTemplates:
+      guard let args = call.arguments as? [String : Any] else {
+        result(false)
+        return
+      }
+      let elementId = args["elementId"] as! String
+      let templates = (args["templates"] as! Array<[String: Any]>).map {
+        FCPListTemplate(obj: $0, templateType: FCPListTemplateTypes.PART_OF_GRID_TEMPLATE)
+      }
+      FlutterCarPlaySceneDelegate.updateTabBarTemplates(elementId: elementId, templates: templates)
+      result(true)
+      break
     case FCPChannelTypes.updateListItem:
       guard let args = call.arguments as? [String : Any] else {
         result(false)

--- a/ios/Classes/models/list/FCPListTemplate.swift
+++ b/ios/Classes/models/list/FCPListTemplate.swift
@@ -66,9 +66,15 @@ class FCPListTemplate {
   }
 
   public func updateSections(sections: [FCPListSection]) {
+    let existingMap = Dictionary(uniqueKeysWithValues: zip(self.objcSections.map { $0.elementId }, self.sections))
+
     self.objcSections = sections
-    self.sections = self.objcSections.map {
-      $0.get
+    self.sections = sections.map { section in
+      if let existing = existingMap[section.elementId] {
+        return existing // reuse existing CPListSection
+      } else {
+        return section.get // create new
+      }
     }
   }
 }

--- a/ios/Classes/models/tabbar/FCPTabBarTemplate.swift
+++ b/ios/Classes/models/tabbar/FCPTabBarTemplate.swift
@@ -35,6 +35,23 @@ class FCPTabBarTemplate {
   public func getTemplates() -> [FCPListTemplate] {
     return objcTemplates
   }
+
+  public func getRawTemplates() -> [CPTemplate] {
+    return templates
+  }
+
+  public func updateTemplates(templates: [FCPListTemplate]) {
+    var existingMap = Dictionary(uniqueKeysWithValues: zip(self.objcTemplates.map { $0.elementId }, self.templates))
+
+    self.objcTemplates = templates
+    self.templates = templates.map { template in
+      if let existing = existingMap[template.elementId] {
+        return existing // reuse existing template
+      } else {
+        return template.get // create new template
+      }
+    }
+  }
 }
 
 @available(iOS 14.0, *)

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -206,6 +206,28 @@ class FlutterCarplay {
     return;
   }
 
+  /// It will update the templates of the [CPTabBarTemplate] which has the given [elementId].
+  Future<void> updateTabBarTemplates({
+    required String elementId,
+    required List<CPListTemplate> templates,
+  }) async {
+    final bool? isCompleted = await _carPlayController.methodChannel
+        .invokeMethod('updateTabBarTemplates', <String, dynamic>{
+      'elementId': elementId,
+      'templates': templates
+          .map((CPListTemplate template) => template.toJson())
+          .toList(),
+    });
+
+    if (isCompleted == true) {
+      final template =
+          FlutterCarPlayController.getTemplateFromHistory<CPTabBarTemplate>(
+              elementId);
+      template?.updateTemplates(templates);
+    }
+    return;
+  }
+
   /// Getter for current root template.
   /// Return one of type [CPTabBarTemplate], [CPGridTemplate], [CPListTemplate]
   static dynamic get rootTemplate {

--- a/lib/models/list/list_template.dart
+++ b/lib/models/list/list_template.dart
@@ -92,8 +92,9 @@ class CPListTemplate implements CPTemplate {
   }
 
   void updateSections(List<CPListSection> newSections) {
+    final copy = List<CPListSection>.from(newSections);
     sections
       ..clear()
-      ..addAll(newSections);
+      ..addAll(copy);
   }
 }

--- a/lib/models/tabbar/tabbar_template.dart
+++ b/lib/models/tabbar/tabbar_template.dart
@@ -39,4 +39,11 @@ class CPTabBarTemplate implements CPTemplate {
   String get uniqueId {
     return _elementId;
   }
+
+  void updateTemplates(List<CPListTemplate> newTemplates) {
+    final copy = List<CPListTemplate>.from(newTemplates);
+    templates
+      ..clear()
+      ..addAll(copy);
+  }
 }


### PR DESCRIPTION
**New feature :** 

Update tabBar templates

This allow updating a tabBar without removing entire stack. This is useful to add, update or remove tabs.

**Bugfix :**

- Ensure that updateSections only recreate necessary entries.
- Ensure that updateSections take and memorise new entries (by using List.from).