### PR TITLE
add CPSearchTemplate support

### DIFF
--- a/ios/Classes/FCPEnums.swift
+++ b/ios/Classes/FCPEnums.swift
@@ -43,6 +43,11 @@ enum FCPChannelTypes {
   static let getMaximumNumberOfGridImages = "getMaximumNumberOfGridImages"
   static let getMaximumSectionCount = "getMaximumSectionCount"
   static let getMaximumItemCount = "getMaximumItemCount"
+  static let onSearchTextUpdated = "onSearchTextUpdated"
+  static let onSearchResultSelected = "onSearchResultSelected"
+  static let onSearchButtonPressed = "onSearchButtonPressed"
+  static let updateSearchResults = "updateSearchResults"
+  static let onSearchResultSelectedComplete = "onSearchResultSelectedComplete"
 }
 
 enum FCPAlertActionTypes {

--- a/ios/Classes/SwiftFlutterCarplayPlugin.swift
+++ b/ios/Classes/SwiftFlutterCarplayPlugin.swift
@@ -80,6 +80,9 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       case String(describing: FCPListTemplate.self):
         rootTemplate = FCPListTemplate(obj: data)
         break
+      case String(describing: FCPSearchTemplate.self):
+        rootTemplate = FCPSearchTemplate(obj: data)
+        break
       default:
         result(false)
         return
@@ -344,6 +347,9 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       case String(describing: FCPListTemplate.self):
         template = FCPListTemplate(obj: data)
         break
+      case String(describing: FCPSearchTemplate.self):
+        template = FCPSearchTemplate(obj: data)
+        break
       default:
         result(false)
         return
@@ -357,6 +363,37 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       } else {
         result(false)
       }
+      break
+    case FCPChannelTypes.updateSearchResults:
+      guard let args = call.arguments as? [String : Any] else {
+        result(false)
+        return
+      }
+      let elementId = args["elementId"] as! String
+      let items = (args["searchResults"] as! Array<[String : Any]>).map {
+        FCPListItem(obj: $0)
+      }
+      for template in SwiftFlutterCarplayPlugin.templateStack {
+        if let searchTemplate = template as? FCPSearchTemplate, searchTemplate.elementId == elementId {
+          searchTemplate.updateSearchResults(items: items)
+          break
+        }
+      }
+      result(true)
+      break
+    case FCPChannelTypes.onSearchResultSelectedComplete:
+      guard let args = call.arguments as? [String : Any] else {
+        result(false)
+        return
+      }
+      let elementId = args["elementId"] as! String
+      for template in SwiftFlutterCarplayPlugin.templateStack {
+        if let searchTemplate = template as? FCPSearchTemplate, searchTemplate.elementId == elementId {
+          searchTemplate.completeSelectedResult()
+          break
+        }
+      }
+      result(true)
       break
     case FCPChannelTypes.popToRootTemplate:
       guard let animated = call.arguments as? Bool,
@@ -412,6 +449,13 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
         }
       } else if let list = template as? FCPListTemplate {
         collected.append(list)
+      } else if let search = template as? FCPSearchTemplate {
+        for item in search.getCurrentResultItems() {
+          if item.elementId == elementId {
+            actionWhenFound(item)
+            return
+          }
+        }
       }
     }
 

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -9,7 +9,7 @@ import CarPlay
 class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   private(set) var _super: CPSearchTemplate?
   private(set) var elementId: String
-  private var searchCompletionHandler: (([CPListItem]) -> Void)?
+  private var searchCompletionHandler: (([any CPListTemplateItem]) -> Void)?
   private var selectedCompletionHandler: (() -> Void)?
   private var currentResultItems: [FCPListItem] = []
 
@@ -25,7 +25,7 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
     return searchTemplate
   }
 
-  func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void) {
+  func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([any CPListTemplateItem]) -> Void) {
     self.searchCompletionHandler = completionHandler
     DispatchQueue.main.async {
       FCPStreamHandlerPlugin.sendEvent(

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -1,0 +1,83 @@
+//
+//  FCPSearchTemplate.swift
+//  flutter_carplay
+//
+
+import CarPlay
+
+@available(iOS 14.0, *)
+class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
+  private(set) var _super: CPSearchTemplate?
+  private(set) var elementId: String
+  private var searchCompletionHandler: (([CPListItem]) -> Void)?
+  private var selectedCompletionHandler: (() -> Void)?
+  private var currentResultItems: [FCPListItem] = []
+
+  init(obj: [String: Any]) {
+    self.elementId = obj["_elementId"] as! String
+    super.init()
+  }
+
+  var get: CPTemplate {
+    let searchTemplate = CPSearchTemplate()
+    searchTemplate.delegate = self
+    searchTemplate.elementId = self.elementId
+    self._super = searchTemplate
+    return searchTemplate
+  }
+
+  func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void) {
+    self.searchCompletionHandler = completionHandler
+    DispatchQueue.main.async {
+      FCPStreamHandlerPlugin.sendEvent(
+        type: FCPChannelTypes.onSearchTextUpdated,
+        data: ["elementId": self.elementId, "searchText": searchText]
+      )
+    }
+  }
+
+  func searchTemplate(_ searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void) {
+    self.selectedCompletionHandler = completionHandler
+    var selectedElementId = ""
+    for fcpItem in currentResultItems {
+      if fcpItem._super === item {
+        selectedElementId = fcpItem.elementId
+        break
+      }
+    }
+    DispatchQueue.main.async {
+      FCPStreamHandlerPlugin.sendEvent(
+        type: FCPChannelTypes.onSearchResultSelected,
+        data: ["elementId": self.elementId, "itemElementId": selectedElementId]
+      )
+    }
+  }
+
+  func searchTemplateSearchButtonPressed(_ searchTemplate: CPSearchTemplate) {
+    DispatchQueue.main.async {
+      FCPStreamHandlerPlugin.sendEvent(
+        type: FCPChannelTypes.onSearchButtonPressed,
+        data: ["elementId": self.elementId]
+      )
+    }
+  }
+
+  public func updateSearchResults(items: [FCPListItem]) {
+    self.currentResultItems = items
+    let cpItems = items.map { $0.get }
+    self.searchCompletionHandler?(cpItems)
+    self.searchCompletionHandler = nil
+  }
+
+  public func completeSelectedResult() {
+    self.selectedCompletionHandler?()
+    self.selectedCompletionHandler = nil
+  }
+
+  public func getCurrentResultItems() -> [FCPListItem] {
+    return currentResultItems
+  }
+}
+
+@available(iOS 14.0, *)
+extension FCPSearchTemplate: FCPRootTemplate {}

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -9,7 +9,7 @@ import CarPlay
 class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   private(set) var _super: CPSearchTemplate?
   private(set) var elementId: String
-  private var searchCompletionHandler: (([any CPListTemplateItem]) -> Void)?
+  private var searchCompletionHandler: (([CPListItem]) -> Void)?
   private var selectedCompletionHandler: (() -> Void)?
   private var currentResultItems: [FCPListItem] = []
 
@@ -25,7 +25,7 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
     return searchTemplate
   }
 
-  func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([any CPListTemplateItem]) -> Void) {
+  func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void) {
     self.searchCompletionHandler = completionHandler
     DispatchQueue.main.async {
       FCPStreamHandlerPlugin.sendEvent(
@@ -63,7 +63,7 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
 
   public func updateSearchResults(items: [FCPListItem]) {
     self.currentResultItems = items
-    let cpItems: [any CPListTemplateItem] = items.map { $0.get }
+    let cpItems = items.compactMap { $0.get as? CPListItem }
     self.searchCompletionHandler?(cpItems)
     self.searchCompletionHandler = nil
   }
@@ -76,4 +76,9 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   public func getCurrentResultItems() -> [FCPListItem] {
     return currentResultItems
   }
+}
+
+@available(iOS 14.0, *)
+extension FCPSearchTemplate: FCPTemplate {
+  public func update(with template: any FCPTemplate) {}
 }

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -63,7 +63,7 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
 
   public func updateSearchResults(items: [FCPListItem]) {
     self.currentResultItems = items
-    let cpItems = items.map { $0.get }
+    let cpItems: [any CPListTemplateItem] = items.map { $0.get }
     self.searchCompletionHandler?(cpItems)
     self.searchCompletionHandler = nil
   }

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -15,7 +15,6 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
 
   init(obj: [String: Any]) {
     self.elementId = obj["_elementId"] as! String
-    super.init()
   }
 
   var get: CPTemplate {

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -77,6 +77,3 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
     return currentResultItems
   }
 }
-
-@available(iOS 14.0, *)
-extension FCPSearchTemplate: FCPRootTemplate {}

--- a/ios/Classes/models/search/FCPSearchTemplate.swift
+++ b/ios/Classes/models/search/FCPSearchTemplate.swift
@@ -12,9 +12,13 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   private var searchCompletionHandler: (([CPListItem]) -> Void)?
   private var selectedCompletionHandler: (() -> Void)?
   private var currentResultItems: [FCPListItem] = []
+  private var hasSearchTextCallback: Bool
+  private var hasSelectedResultCallback: Bool
 
   init(obj: [String: Any]) {
     self.elementId = obj["_elementId"] as! String
+    self.hasSearchTextCallback = obj["onUpdatedSearchText"] as? Bool ?? false
+    self.hasSelectedResultCallback = obj["onSelectedResult"] as? Bool ?? false
   }
 
   var get: CPTemplate {
@@ -26,6 +30,10 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   }
 
   func searchTemplate(_ searchTemplate: CPSearchTemplate, updatedSearchText searchText: String, completionHandler: @escaping ([CPListItem]) -> Void) {
+    guard hasSearchTextCallback else {
+      completionHandler([])
+      return
+    }
     self.searchCompletionHandler = completionHandler
     DispatchQueue.main.async {
       FCPStreamHandlerPlugin.sendEvent(
@@ -36,7 +44,10 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   }
 
   func searchTemplate(_ searchTemplate: CPSearchTemplate, selectedResult item: CPListItem, completionHandler: @escaping () -> Void) {
-    self.selectedCompletionHandler = completionHandler
+    guard hasSelectedResultCallback else {
+      completionHandler()
+      return
+    }
     var selectedElementId = ""
     for fcpItem in currentResultItems {
       if fcpItem._super === item {
@@ -44,6 +55,11 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
         break
       }
     }
+    guard !selectedElementId.isEmpty else {
+      completionHandler()
+      return
+    }
+    self.selectedCompletionHandler = completionHandler
     DispatchQueue.main.async {
       FCPStreamHandlerPlugin.sendEvent(
         type: FCPChannelTypes.onSearchResultSelected,
@@ -76,9 +92,9 @@ class FCPSearchTemplate: NSObject, CPSearchTemplateDelegate {
   public func getCurrentResultItems() -> [FCPListItem] {
     return currentResultItems
   }
+
+  public func update(with template: any FCPTemplate) {}
 }
 
 @available(iOS 14.0, *)
-extension FCPSearchTemplate: FCPTemplate {
-  public func update(with template: any FCPTemplate) {}
-}
+extension FCPSearchTemplate: FCPTemplate {}

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_carplay/controllers/carplay_controller.dart';
 import 'package:flutter_carplay/flutter_carplay.dart';
+import 'package:flutter_carplay/models/search/search_template.dart';
 
 /// An object in order to integrate Apple CarPlay in navigation and
 /// manage all user interface elements appearing on your screens displayed on
@@ -94,6 +95,23 @@ class FlutterCarplay {
             event['data']['elementId'],
           );
           break;
+        case FCPChannelTypes.onSearchTextUpdated:
+          _carPlayController.processFCPSearchTextUpdated(
+            event['data']['elementId'],
+            event['data']['searchText'],
+          );
+          break;
+        case FCPChannelTypes.onSearchResultSelected:
+          _carPlayController.processFCPSearchResultSelected(
+            event['data']['elementId'],
+            event['data']['itemElementId'],
+          );
+          break;
+        case FCPChannelTypes.onSearchButtonPressed:
+          _carPlayController.processFCPSearchButtonPressed(
+            event['data']['elementId'],
+          );
+          break;
         case FCPChannelTypes.onScreenBackButtonPressed:
           FlutterCarPlayController.templateHistory.removeWhere(
             (CPTemplate item) => item.uniqueId == event['data']['elementId'],
@@ -165,7 +183,8 @@ class FlutterCarplay {
         rootTemplate is CPGridTemplate ||
         rootTemplate is CPListTemplate ||
         rootTemplate is CPInformationTemplate ||
-        rootTemplate is CPPointOfInterestTemplate) {
+        rootTemplate is CPPointOfInterestTemplate ||
+        rootTemplate is CPSearchTemplate) {
       return FlutterCarPlayController.flutterToNativeModule(
           FCPChannelTypes.setRootTemplate, <String, dynamic>{
         'rootTemplate': rootTemplate.toJson(),
@@ -344,7 +363,8 @@ class FlutterCarplay {
     if (template is CPGridTemplate ||
         template is CPListTemplate ||
         template is CPInformationTemplate ||
-        template is CPPointOfInterestTemplate) {
+        template is CPPointOfInterestTemplate ||
+        template is CPSearchTemplate) {
       final bool? isCompleted =
           await FlutterCarPlayController.flutterToNativeModule(
         FCPChannelTypes.pushTemplate,

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_carplay/controllers/carplay_controller.dart';
 import 'package:flutter_carplay/flutter_carplay.dart';
-import 'package:flutter_carplay/models/search/search_template.dart';
 
 /// An object in order to integrate Apple CarPlay in navigation and
 /// manage all user interface elements appearing on your screens displayed on

--- a/lib/constants/private_constants.dart
+++ b/lib/constants/private_constants.dart
@@ -32,6 +32,7 @@ enum FCPChannelTypes {
   onSearchTextUpdated,
   onSearchResultSelected,
   onSearchButtonPressed,
+  updateSearchResults,
   onSearchResultSelectedComplete,
 }
 

--- a/lib/constants/private_constants.dart
+++ b/lib/constants/private_constants.dart
@@ -29,6 +29,10 @@ enum FCPChannelTypes {
   getMaximumNumberOfGridImages,
   getMaximumSectionCount,
   getMaximumItemCount,
+  onSearchTextUpdated,
+  onSearchResultSelected,
+  onSearchButtonPressed,
+  onSearchResultSelectedComplete,
 }
 
 enum FAAChannelTypes {

--- a/lib/controllers/carplay_controller.dart
+++ b/lib/controllers/carplay_controller.dart
@@ -367,10 +367,13 @@ class FlutterCarPlayController {
                 .whereType<CPListItem>()
                 .map((e) => e.toJson())
                 .toList();
-            _methodChannel.invokeMethod('updateSearchResults', <String, dynamic>{
-              'elementId': elementId,
-              'searchResults': items,
-            });
+            FlutterCarPlayController.flutterToNativeModule(
+              FCPChannelTypes.updateSearchResults,
+              <String, dynamic>{
+                'elementId': elementId,
+                'searchResults': items,
+              },
+            );
           },
         );
         return;
@@ -392,10 +395,10 @@ class FlutterCarPlayController {
           t.onSearchResultSelected?.call(
             selectedItem,
             () {
-              _methodChannel.invokeMethod(
-                  'onSearchResultSelectedComplete', <String, dynamic>{
-                'elementId': elementId,
-              });
+              FlutterCarPlayController.flutterToNativeModule(
+                FCPChannelTypes.onSearchResultSelectedComplete,
+                <String, dynamic>{'elementId': elementId},
+              );
             },
           );
         }

--- a/lib/controllers/carplay_controller.dart
+++ b/lib/controllers/carplay_controller.dart
@@ -212,7 +212,8 @@ class FlutterCarPlayController {
         template is CPGridTemplate ||
         template is CPInformationTemplate ||
         template is CPPointOfInterestTemplate ||
-        template is CPListTemplate) {
+        template is CPListTemplate ||
+        template is CPSearchTemplate) {
       templateHistory.add(template);
     } else {
       throw TypeError();
@@ -351,6 +352,63 @@ class FlutterCarPlayController {
             }
           }
         }
+      }
+    }
+  }
+
+  void processFCPSearchTextUpdated(String elementId, String searchText) {
+    for (var t in templateHistory) {
+      if (t is CPSearchTemplate && t.uniqueId == elementId) {
+        t.onSearchTextUpdated?.call(
+          searchText,
+          (List<dynamic> results) {
+            t.updateResults(results);
+            final items = results
+                .whereType<CPListItem>()
+                .map((e) => e.toJson())
+                .toList();
+            _methodChannel.invokeMethod('updateSearchResults', <String, dynamic>{
+              'elementId': elementId,
+              'searchResults': items,
+            });
+          },
+        );
+        return;
+      }
+    }
+  }
+
+  void processFCPSearchResultSelected(String elementId, String itemElementId) {
+    for (var t in templateHistory) {
+      if (t is CPSearchTemplate && t.uniqueId == elementId) {
+        CPListItem? selectedItem;
+        for (var item in t.currentResults) {
+          if (item is CPListItem && item.uniqueId == itemElementId) {
+            selectedItem = item;
+            break;
+          }
+        }
+        if (selectedItem != null) {
+          t.onSearchResultSelected?.call(
+            selectedItem,
+            () {
+              _methodChannel.invokeMethod(
+                  'onSearchResultSelectedComplete', <String, dynamic>{
+                'elementId': elementId,
+              });
+            },
+          );
+        }
+        return;
+      }
+    }
+  }
+
+  void processFCPSearchButtonPressed(String elementId) {
+    for (var t in templateHistory) {
+      if (t is CPSearchTemplate && t.uniqueId == elementId) {
+        t.onSearchButtonPressed?.call();
+        return;
       }
     }
   }

--- a/lib/controllers/carplay_controller.dart
+++ b/lib/controllers/carplay_controller.dart
@@ -359,14 +359,11 @@ class FlutterCarPlayController {
   void processFCPSearchTextUpdated(String elementId, String searchText) {
     for (var t in templateHistory) {
       if (t is CPSearchTemplate && t.uniqueId == elementId) {
-        t.onSearchTextUpdated?.call(
+        t.onUpdatedSearchText?.call(
           searchText,
-          (List<dynamic> results) {
+          (List<CPListItem> results) {
             t.updateResults(results);
-            final items = results
-                .whereType<CPListItem>()
-                .map((e) => e.toJson())
-                .toList();
+            final items = results.map((e) => e.toJson()).toList();
             FlutterCarPlayController.flutterToNativeModule(
               FCPChannelTypes.updateSearchResults,
               <String, dynamic>{
@@ -386,13 +383,13 @@ class FlutterCarPlayController {
       if (t is CPSearchTemplate && t.uniqueId == elementId) {
         CPListItem? selectedItem;
         for (var item in t.currentResults) {
-          if (item is CPListItem && item.uniqueId == itemElementId) {
+          if (item.uniqueId == itemElementId) {
             selectedItem = item;
             break;
           }
         }
         if (selectedItem != null) {
-          t.onSearchResultSelected?.call(
+          t.onSelectedResult?.call(
             selectedItem,
             () {
               FlutterCarPlayController.flutterToNativeModule(
@@ -410,7 +407,7 @@ class FlutterCarPlayController {
   void processFCPSearchButtonPressed(String elementId) {
     for (var t in templateHistory) {
       if (t is CPSearchTemplate && t.uniqueId == elementId) {
-        t.onSearchButtonPressed?.call();
+        t.onSearchTemplateSearchButtonPressed?.call();
         return;
       }
     }

--- a/lib/models/all.dart
+++ b/lib/models/all.dart
@@ -6,5 +6,6 @@ export 'grid/all.dart';
 export 'information/all.dart';
 export 'list/all.dart';
 export 'poi/all.dart';
+export 'search/all.dart';
 export 'tabbar/all.dart';
 export 'template.dart';

--- a/lib/models/search/all.dart
+++ b/lib/models/search/all.dart
@@ -1,0 +1,1 @@
+export 'search_template.dart';

--- a/lib/models/search/search_template.dart
+++ b/lib/models/search/search_template.dart
@@ -2,24 +2,39 @@ import 'package:uuid/uuid.dart';
 
 import '../template.dart';
 
+/// A template that displays a search interface.
+/// https://developer.apple.com/documentation/carplay/cpsearchtemplate
+/// iOS 14.0+
 class CPSearchTemplate extends CPTemplate {
-  final String _elementId = const Uuid().v4();
+  /// Unique id of the object.
+  final String _elementId;
 
+  /// Called when the user updates the search text.
+  /// Provides the current search text and a callback to update the displayed results.
+  /// iOS 14.0+
   final Function(String searchText, Function(List<dynamic> results) update)?
       onSearchTextUpdated;
 
+  /// Called when the user selects a search result.
+  /// Provides the selected item and a completion callback to dismiss the search interface.
+  /// iOS 14.0+
   final Function(dynamic selectedItem, Function() complete)?
       onSearchResultSelected;
 
+  /// Called when the user taps the search button on the keyboard.
+  /// iOS 14.0+
   final Function()? onSearchButtonPressed;
 
   List<dynamic> _currentResults = [];
 
+  /// Creates [CPSearchTemplate] to display a CarPlay search interface.
   CPSearchTemplate({
+    String? id,
     this.onSearchTextUpdated,
     this.onSearchResultSelected,
     this.onSearchButtonPressed,
-  }) : super();
+  })  : _elementId = id ?? const Uuid().v4(),
+        super();
 
   @override
   Map<String, dynamic> toJson() => {
@@ -36,6 +51,9 @@ class CPSearchTemplate extends CPTemplate {
   List<dynamic> get currentResults => _currentResults;
 
   void updateResults(List<dynamic> results) {
-    _currentResults = List.from(results);
+    final copy = List<dynamic>.from(results);
+    _currentResults
+      ..clear()
+      ..addAll(copy);
   }
 }

--- a/lib/models/search/search_template.dart
+++ b/lib/models/search/search_template.dart
@@ -1,0 +1,41 @@
+import 'package:uuid/uuid.dart';
+
+import '../template.dart';
+
+class CPSearchTemplate extends CPTemplate {
+  final String _elementId = const Uuid().v4();
+
+  final Function(String searchText, Function(List<dynamic> results) update)?
+      onSearchTextUpdated;
+
+  final Function(dynamic selectedItem, Function() complete)?
+      onSearchResultSelected;
+
+  final Function()? onSearchButtonPressed;
+
+  List<dynamic> _currentResults = [];
+
+  CPSearchTemplate({
+    this.onSearchTextUpdated,
+    this.onSearchResultSelected,
+    this.onSearchButtonPressed,
+  }) : super();
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'runtimeType': 'FCPSearchTemplate',
+        '_elementId': _elementId,
+        'onSearchTextUpdated': onSearchTextUpdated != null,
+        'onSearchResultSelected': onSearchResultSelected != null,
+        'onSearchButtonPressed': onSearchButtonPressed != null,
+      };
+
+  @override
+  String get uniqueId => _elementId;
+
+  List<dynamic> get currentResults => _currentResults;
+
+  void updateResults(List<dynamic> results) {
+    _currentResults = List.from(results);
+  }
+}

--- a/lib/models/search/search_template.dart
+++ b/lib/models/search/search_template.dart
@@ -1,38 +1,37 @@
 import 'package:uuid/uuid.dart';
 
+import '../list/list_item.dart';
 import '../template.dart';
 
-/// A template that displays a search interface.
+/// A template that provides the ability to search for a destination and see a list of search results.
 /// https://developer.apple.com/documentation/carplay/cpsearchtemplate
-/// iOS 14.0+
+/// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
 class CPSearchTemplate extends CPTemplate {
   /// Unique id of the object.
   final String _elementId;
 
-  /// Called when the user updates the search text.
-  /// Provides the current search text and a callback to update the displayed results.
-  /// iOS 14.0+
-  final Function(String searchText, Function(List<dynamic> results) update)?
-      onSearchTextUpdated;
+  /// Tells the delegate that the user updated the search criteria text.
+  /// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
+  final Function(String searchText, Function(List<CPListItem> results) update)?
+      onUpdatedSearchText;
 
-  /// Called when the user selects a search result.
-  /// Provides the selected item and a completion callback to dismiss the search interface.
-  /// iOS 14.0+
-  final Function(dynamic selectedItem, Function() complete)?
-      onSearchResultSelected;
+  /// Tells the delegate that the user selected an item from the search result.
+  /// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
+  final Function(CPListItem selectedItem, Function() complete)?
+      onSelectedResult;
 
-  /// Called when the user taps the search button on the keyboard.
-  /// iOS 14.0+
-  final Function()? onSearchButtonPressed;
+  /// Tells the delegate that the user tapped the keyboard's search button.
+  /// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
+  final Function()? onSearchTemplateSearchButtonPressed;
 
-  List<dynamic> _currentResults = [];
+  final List<CPListItem> _currentResults = [];
 
   /// Creates [CPSearchTemplate] to display a CarPlay search interface.
   CPSearchTemplate({
     String? id,
-    this.onSearchTextUpdated,
-    this.onSearchResultSelected,
-    this.onSearchButtonPressed,
+    this.onUpdatedSearchText,
+    this.onSelectedResult,
+    this.onSearchTemplateSearchButtonPressed,
   })  : _elementId = id ?? const Uuid().v4(),
         super();
 
@@ -40,18 +39,19 @@ class CPSearchTemplate extends CPTemplate {
   Map<String, dynamic> toJson() => {
         'runtimeType': 'FCPSearchTemplate',
         '_elementId': _elementId,
-        'onSearchTextUpdated': onSearchTextUpdated != null,
-        'onSearchResultSelected': onSearchResultSelected != null,
-        'onSearchButtonPressed': onSearchButtonPressed != null,
+        'onUpdatedSearchText': onUpdatedSearchText != null,
+        'onSelectedResult': onSelectedResult != null,
+        'onSearchTemplateSearchButtonPressed':
+            onSearchTemplateSearchButtonPressed != null,
       };
 
   @override
   String get uniqueId => _elementId;
 
-  List<dynamic> get currentResults => _currentResults;
+  List<CPListItem> get currentResults => _currentResults;
 
-  void updateResults(List<dynamic> results) {
-    final copy = List<dynamic>.from(results);
+  void updateResults(List<CPListItem> results) {
+    final copy = List<CPListItem>.from(results);
     _currentResults
       ..clear()
       ..addAll(copy);


### PR DESCRIPTION
  ## Summary
  - Add `CPSearchTemplate` wrapping Apple's `CPSearchTemplate` API for CarPlay search functionality
  - Search results use existing `CPListItem` — no new item types needed
  - Three delegate callbacks bridged to Dart: `onSearchTextUpdated`, `onSearchResultSelected`,
  `onSearchButtonPressed`

  ## Changes
  - **New**: `FCPSearchTemplate.swift` — Swift wrapper implementing `CPSearchTemplateDelegate`
  - **New**: `search_template.dart` — Dart model with callback-based API
  - **Modified**: Plugin entry point, enums, controller, worker, and barrel export to register the new
   template across the full method channel bridge

  ## Usage
  ```dart
  CPSearchTemplate(
    onSearchTextUpdated: (searchText, updateResults) {
      final results = await search(searchText);
      updateResults(results.map((r) => CPListItem(text: r.title)).toList());
    },
    onSearchResultSelected: (item, complete) {
      // handle selection
      complete();
    },
    onSearchButtonPressed: () {},
  )