### PR TITLE
add dynamic update support for FCPInformationTemplate items and actions

### DIFF
--- a/ios/Classes/FCPEnums.swift
+++ b/ios/Classes/FCPEnums.swift
@@ -17,6 +17,8 @@ enum FCPChannelTypes {
   static let forceUpdateRootTemplate = "forceUpdateRootTemplate"
   static let updateListTemplateSections = "updateListTemplateSections"
   static let updateTabBarTemplates = "updateTabBarTemplates"
+  static let updateInformationTemplateItems = "updateInformationTemplateItems"
+  static let updateInformationTemplateActions = "updateInformationTemplateActions"
   static let updateListItem = "updateListItem"
   static let updateListImageRowItem = "updateListImageRowItem"
   static let updateListImageRowItemElement = "updateListImageRowItemElement"

--- a/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
+++ b/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
@@ -50,7 +50,6 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     templateFromHistory.updateSections(sections: sections)
   }
 
-  // https://developer.apple.com/documentation/carplay/cpinformationtemplate/items
   static public func updateInformationTemplateItems(elementId: String, items: [FCPInformationItem]) {
     guard let templateFromHistory = SwiftFlutterCarplayPlugin.getTemplateFromHistory(elementId: elementId) as? FCPInformationTemplate else {
       NSLog("FlutterCarPlaySceneDelegate - updateInformationTemplateItems: Template from history with elementId \(elementId) not found.")
@@ -60,7 +59,6 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     templateFromHistory.updateInformationItems(items: items)
   }
 
-  // https://developer.apple.com/documentation/carplay/cpinformationtemplate/actions
   static public func updateInformationTemplateActions(elementId: String, actions: [FCPTextButton]) {
     guard let templateFromHistory = SwiftFlutterCarplayPlugin.getTemplateFromHistory(elementId: elementId) as? FCPInformationTemplate else {
       NSLog("FlutterCarPlaySceneDelegate - updateInformationTemplateActions: Template from history with elementId \(elementId) not found.")

--- a/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
+++ b/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
@@ -50,6 +50,26 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     templateFromHistory.updateSections(sections: sections)
   }
 
+  // https://developer.apple.com/documentation/carplay/cpinformationtemplate/items
+  static public func updateInformationTemplateItems(elementId: String, items: [FCPInformationItem]) {
+    guard let templateFromHistory = SwiftFlutterCarplayPlugin.getTemplateFromHistory(elementId: elementId) as? FCPInformationTemplate else {
+      NSLog("FlutterCarPlaySceneDelegate - updateInformationTemplateItems: Template from history with elementId \(elementId) not found.")
+      return
+    }
+
+    templateFromHistory.updateInformationItems(items: items)
+  }
+
+  // https://developer.apple.com/documentation/carplay/cpinformationtemplate/actions
+  static public func updateInformationTemplateActions(elementId: String, actions: [FCPTextButton]) {
+    guard let templateFromHistory = SwiftFlutterCarplayPlugin.getTemplateFromHistory(elementId: elementId) as? FCPInformationTemplate else {
+      NSLog("FlutterCarPlaySceneDelegate - updateInformationTemplateActions: Template from history with elementId \(elementId) not found.")
+      return
+    }
+
+    templateFromHistory.updateActions(actions: actions)
+  }
+
   // https://developer.apple.com/documentation/carplay/cptabbartemplate/updatetemplates(_:)
   static public func updateTabBarTemplates(elementId: String, templates: [FCPTemplate]) {
     guard

--- a/ios/Classes/SwiftFlutterCarplayPlugin.swift
+++ b/ios/Classes/SwiftFlutterCarplayPlugin.swift
@@ -134,6 +134,30 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       FlutterCarPlaySceneDelegate.updateTabBarTemplates(elementId: elementId, templates: templates)
       result(true)
       break
+    case FCPChannelTypes.updateInformationTemplateItems:
+      guard let args = call.arguments as? [String : Any] else {
+        result(false)
+        return
+      }
+      let elementId = args["elementId"] as! String
+      let items = (args["items"] as! Array<[String: Any]>).map {
+        FCPInformationItem(obj: $0)
+      }
+      FlutterCarPlaySceneDelegate.updateInformationTemplateItems(elementId: elementId, items: items)
+      result(true)
+      break
+    case FCPChannelTypes.updateInformationTemplateActions:
+      guard let args = call.arguments as? [String : Any] else {
+        result(false)
+        return
+      }
+      let elementId = args["elementId"] as! String
+      let actions = (args["actions"] as! Array<[String: Any]>).map {
+        FCPTextButton(obj: $0)
+      }
+      FlutterCarPlaySceneDelegate.updateInformationTemplateActions(elementId: elementId, actions: actions)
+      result(true)
+      break
     case FCPChannelTypes.updateListItem:
       guard let args = call.arguments as? [String: Any] else {
         result(false)

--- a/ios/Classes/models/information/FCPInformationTemplate.swift
+++ b/ios/Classes/models/information/FCPInformationTemplate.swift
@@ -50,13 +50,11 @@ class FCPInformationTemplate {
   var get: CPTemplate {
     let informationTemplate = CPInformationTemplate.init(
       title: self.title, layout: self.layout, items: informationItems, actions: actions)
-
     informationTemplate.tabTitle = tabTitle
     informationTemplate.showsTabBadge = showsTabBadge
     if let systemIcon = systemIcon {
       informationTemplate.tabImage = UIImage(systemName: systemIcon)
     }
-
     informationTemplate.elementId = self.elementId
     self._super = informationTemplate
     return informationTemplate
@@ -66,6 +64,18 @@ class FCPInformationTemplate {
     guard let with = with as? FCPInformationTemplate else {
       return
     }
+  }
+
+  public func updateInformationItems(items: [FCPInformationItem]) {
+    self.objcInformationItems = items
+    self.informationItems = items.map { $0.get }
+    _super?.items = self.informationItems
+  }
+
+  public func updateActions(actions: [FCPTextButton]) {
+    self.objcActions = actions
+    self.actions = actions.map { $0.get }
+    _super?.actions = self.actions
   }
 }
 @available(iOS 14.0, *)

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -218,11 +218,14 @@ class FlutterCarplay {
     required String elementId,
     required List<CPInformationItem> items,
   }) async {
-    final bool? isCompleted = await _carPlayController.methodChannel
-        .invokeMethod('updateInformationTemplateItems', <String, dynamic>{
-      'elementId': elementId,
-      'items': items.map((CPInformationItem item) => item.toJson()).toList(),
-    });
+    final bool? isCompleted =
+        await FlutterCarPlayController.flutterToNativeModule(
+      FCPChannelTypes.updateInformationTemplateItems,
+      <String, dynamic>{
+        'elementId': elementId,
+        'items': items.map((CPInformationItem item) => item.toJson()).toList(),
+      },
+    );
 
     if (isCompleted == true) {
       final template = FlutterCarPlayController
@@ -237,12 +240,15 @@ class FlutterCarplay {
     required String elementId,
     required List<CPTextButton> actions,
   }) async {
-    final bool? isCompleted = await _carPlayController.methodChannel
-        .invokeMethod('updateInformationTemplateActions', <String, dynamic>{
-      'elementId': elementId,
-      'actions':
-          actions.map((CPTextButton action) => action.toJson()).toList(),
-    });
+    final bool? isCompleted =
+        await FlutterCarPlayController.flutterToNativeModule(
+      FCPChannelTypes.updateInformationTemplateActions,
+      <String, dynamic>{
+        'elementId': elementId,
+        'actions':
+            actions.map((CPTextButton action) => action.toJson()).toList(),
+      },
+    );
 
     if (isCompleted == true) {
       final template = FlutterCarPlayController

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -213,6 +213,45 @@ class FlutterCarplay {
     return;
   }
 
+  /// It will update the information items of the [CPInformationTemplate] which has the given [elementId].
+  Future<void> updateInformationTemplateItems({
+    required String elementId,
+    required List<CPInformationItem> items,
+  }) async {
+    final bool? isCompleted = await _carPlayController.methodChannel
+        .invokeMethod('updateInformationTemplateItems', <String, dynamic>{
+      'elementId': elementId,
+      'items': items.map((CPInformationItem item) => item.toJson()).toList(),
+    });
+
+    if (isCompleted == true) {
+      final template = FlutterCarPlayController
+          .getTemplateFromHistory<CPInformationTemplate>(elementId);
+      template?.updateInformationItems(items);
+    }
+    return;
+  }
+
+  /// It will update the actions of the [CPInformationTemplate] which has the given [elementId].
+  Future<void> updateInformationTemplateActions({
+    required String elementId,
+    required List<CPTextButton> actions,
+  }) async {
+    final bool? isCompleted = await _carPlayController.methodChannel
+        .invokeMethod('updateInformationTemplateActions', <String, dynamic>{
+      'elementId': elementId,
+      'actions':
+          actions.map((CPTextButton action) => action.toJson()).toList(),
+    });
+
+    if (isCompleted == true) {
+      final template = FlutterCarPlayController
+          .getTemplateFromHistory<CPInformationTemplate>(elementId);
+      template?.updateActions(actions);
+    }
+    return;
+  }
+
   /// It will update the templates of the [CPTabBarTemplate] which has the given [elementId].
   /// Supported template types: [CPListTemplate], [CPPointOfInterestTemplate],
   /// [CPGridTemplate], [CPInformationTemplate]

--- a/lib/constants/private_constants.dart
+++ b/lib/constants/private_constants.dart
@@ -26,6 +26,8 @@ enum FCPChannelTypes {
   onScreenBackButtonPressed,
   updateTabBarTemplates,
   updateListTemplateSections,
+  updateInformationTemplateItems,
+  updateInformationTemplateActions,
   getMaximumNumberOfGridImages,
   getMaximumSectionCount,
   getMaximumItemCount,

--- a/lib/models/information/information_template.dart
+++ b/lib/models/information/information_template.dart
@@ -57,4 +57,18 @@ class CPInformationTemplate extends CPTemplate {
   String get uniqueId {
     return _elementId;
   }
+
+  void updateInformationItems(List<CPInformationItem> newItems) {
+    final copy = List<CPInformationItem>.from(newItems);
+    informationItems
+      ..clear()
+      ..addAll(copy);
+  }
+
+  void updateActions(List<CPTextButton> newActions) {
+    final copy = List<CPTextButton>.from(newActions);
+    actions
+      ..clear()
+      ..addAll(copy);
+  }
 }


### PR DESCRIPTION
## Summary
  - Adds `updateInformationTemplateItems` and `updateInformationTemplateActions` methods to
  dynamically update a displayed `CPInformationTemplate`, mirroring the existing
  `updateListTemplateSections` pattern for `CPListTemplate`.
  - Fixes a bug where `FCPInformationTemplate._super` was never assigned, which would have prevented
  any future native-side updates.

  ## Changes
  - **Swift**: Added `updateInformationItems`/`updateActions` to `FCPInformationTemplate`, method
  channel handlers, scene delegate methods, and channel type constants
  - **Dart**: Added mutation methods on `CPInformationTemplate` and public API methods on
  `FlutterCarplay`

  ## Usage
  ```dart
  flutterCarplay.updateInformationTemplateItems(
    elementId: template.uniqueId,
    items: [CPInformationItem(title: 'ETA', detail: '5 min')],
  );

  flutterCarplay.updateInformationTemplateActions(
    elementId: template.uniqueId,
    actions: [CPTextButton(title: 'Cancel', onPress: () {})],
  );