### PR TITLE
fix: Avoid crash on iOS 18 when template list is smaller than the giv…

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.11"
+    version: "1.3.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/Classes/models/list/FCPListImageRowItem.swift
+++ b/ios/Classes/models/list/FCPListImageRowItem.swift
@@ -124,7 +124,8 @@ final class FCPListImageRowItem {
         listImageRowItem = CPListImageRowItem.init(text: text ?? "", images: placeholderImages)
       }
 
-      for (index, imagePath) in gridImages.enumerated() {
+      let maxCount = listImageRowItem.gridImages.count
+      for (index, imagePath) in gridImages.prefix(maxCount).enumerated() {
         let imageSource = imagePath.toImageSource()
         loadUIImageAsync(from: imageSource) { uiImage in
           if let uiImage = uiImage {


### PR DESCRIPTION
A `CPListImageRowItem` may truncate its items to display a shorter list. This fix prevents crashes on iOS 18 and earlier.
