### PR TITLE
docs: prepare 1.3.1 release notes and docs follow ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Implement CPListImageRowItem with full support for cardElements, condensedElements, elements, gridElements, and imageGridElements (#94) (ty @EArminjon)
 - Support individual update for CPListImageRowItem and CPListImageRowItemElement
+- Add update methods for CPInformationTemplate items and actions (#97) (ty @sINFdorako)
 - Expose tabTitle, systemIcon, and showsTabBadges on CPTabBarTemplate
 - Rename enums and classes to be 1:1 with Apple documentation (breaking change)
 - Rework UUID logic to allow custom elementId on all models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.1
 
 - Fix crash on iOS 18 and earlier when `CPListImageRowItem` is truncated by the host and fewer image slots are available than requested (#98) (ty @EArminjon)
+- Add update methods for CPInformationTemplate items and actions (#97) (ty @sINFdorako)
 - Document `CPListImageRowItem` support and `CPInformationTemplate` update methods in the README
 - Update the security policy supported versions to include `1.3.x`
 
@@ -8,7 +9,6 @@
 
 - Implement CPListImageRowItem with full support for cardElements, condensedElements, elements, gridElements, and imageGridElements (#94) (ty @EArminjon)
 - Support individual update for CPListImageRowItem and CPListImageRowItemElement
-- Add update methods for CPInformationTemplate items and actions (#97) (ty @sINFdorako)
 - Expose tabTitle, systemIcon, and showsTabBadges on CPTabBarTemplate
 - Rename enums and classes to be 1:1 with Apple documentation (breaking change)
 - Rework UUID logic to allow custom elementId on all models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.1
+
+- Fix crash on iOS 18 and earlier when `CPListImageRowItem` is truncated by the host and fewer image slots are available than requested (#98) (ty @EArminjon)
+- Document `CPListImageRowItem` support and `CPInformationTemplate` update methods in the README
+- Update the security policy supported versions to include `1.3.x`
+
 ## 1.3.0
 
 - Implement CPListImageRowItem with full support for cardElements, condensedElements, elements, gridElements, and imageGridElements (#94) (ty @EArminjon)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ https://developer.android.com/design/ui/cars/guides/templates/overview
 - [x] Alert Template
 - [x] Grid Template
 - [x] List Template
-- [x] List Image Row Item (v1.3.0)
 - [x] Tab Bar Template
 - [x] Information Template (contribution from [OSch11](https://github.com/OSch11/flutter_carplay))
 - [x] Point of Interest Template (contribution from [OSch11](https://github.com/OSch11/flutter_carplay))
@@ -97,7 +96,7 @@ By evaluating this information, you can request for the relevant entitlement fro
 ## v1.3.0
 
 - **🖼️ CPListImageRowItem**: Added support for image row list items, including element based layouts on newer iOS versions
-- **🔄 Information Template Updates**: Added update methods for information items and actions without rebuilding the whole template
+- **🔄 Information Template Updates**: Added update methods for information items and actions without rebuilding the whole template, thanks to [@sINFdorako](https://github.com/sINFdorako)
 - **🧩 Better Tab Bar Configuration**: `tabTitle`, `systemIcon`, and `showsTabBadge` are now exposed consistently on templates
 - **🛠️ API Polish**: Added custom ids across models, convenient update helpers, and improved image loading reliability
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ By evaluating this information, you can request for the relevant entitlement fro
 
 # What's New in latest versions
 
+## v1.3.1
+
+- **🩹 CPListImageRowItem Crash Fix**: Fixes a crash on iOS 18 and earlier when the host truncates the image row and exposes fewer slots than requested
+- **📚 Documentation Updates**: Adds README coverage for `CPListImageRowItem` and dynamic `CPInformationTemplate` updates
+- **🔐 Security Policy Refresh**: Marks `1.3.x` as a supported version line in `SECURITY.md`
+
 ## v1.3.0
 
 - **🖼️ CPListImageRowItem**: Added support for image row list items, including element based layouts on newer iOS versions

--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ By evaluating this information, you can request for the relevant entitlement fro
 
 # What's New in latest versions
 
-## v1.3.1
-
-- **🩹 CPListImageRowItem Crash Fix**: Fixes a crash on iOS 18 and earlier when the host truncates the image row and exposes fewer slots than requested
-- **📚 Documentation Updates**: Adds README coverage for `CPListImageRowItem` and dynamic `CPInformationTemplate` updates
-- **🔐 Security Policy Refresh**: Marks `1.3.x` as a supported version line in `SECURITY.md`
-
 ## v1.3.0
 
 - **🖼️ CPListImageRowItem**: Added support for image row list items, including element based layouts on newer iOS versions

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ https://developer.android.com/design/ui/cars/guides/templates/overview
 - [x] Alert Template
 - [x] Grid Template
 - [x] List Template
+- [x] List Image Row Item (v1.3.0)
 - [x] Tab Bar Template
 - [x] Information Template (contribution from [OSch11](https://github.com/OSch11/flutter_carplay))
 - [x] Point of Interest Template (contribution from [OSch11](https://github.com/OSch11/flutter_carplay))
@@ -92,6 +93,13 @@ By evaluating this information, you can request for the relevant entitlement fro
 - [x] Now Playing Template (Automatically handled by Android Auto system)
 
 # What's New in latest versions
+
+## v1.3.0
+
+- **🖼️ CPListImageRowItem**: Added support for image row list items, including element based layouts on newer iOS versions
+- **🔄 Information Template Updates**: Added update methods for information items and actions without rebuilding the whole template
+- **🧩 Better Tab Bar Configuration**: `tabTitle`, `systemIcon`, and `showsTabBadge` are now exposed consistently on templates
+- **🛠️ API Polish**: Added custom ids across models, convenient update helpers, and improved image loading reliability
 
 ## v1.2.0
 
@@ -811,6 +819,64 @@ FlutterCarplay.push(template: informationTemplate, animated: true);
 FlutterCarplay.setRootTemplate(rootTemplate: informationTemplate, animated: true);
 // You need to call _flutterCarplay.forceUpdateRootTemplate(); after setting the root template
 ```
+
+You can also update an existing `CPInformationTemplate` without rebuilding the full template.
+
+```dart
+await _flutterCarplay.updateInformationTemplateItems(
+  elementId: informationTemplate.uniqueId,
+  items: [
+    CPInformationItem(title: "Battery", detail: "85%"),
+    CPInformationItem(title: "Range", detail: "240 km"),
+  ],
+);
+
+await _flutterCarplay.updateInformationTemplateActions(
+  elementId: informationTemplate.uniqueId,
+  actions: [
+    CPTextButton(
+      title: "Refresh",
+      onPress: () {
+        print("Refresh tapped");
+      },
+    ),
+  ],
+);
+```
+
+### List Image Row Item
+
+`CPListImageRowItem` lets you show a row of multiple images inside a `CPListTemplate` section.
+
+```dart
+final CPListTemplate listTemplate = CPListTemplate(
+  title: "Gallery",
+  sections: [
+    CPListSection(
+      items: [
+        CPListImageRowItem(
+          text: "Recently played",
+          gridImages: [
+            "https://picsum.photos/200/200?1",
+            "https://picsum.photos/200/200?2",
+            "https://picsum.photos/200/200?3",
+          ],
+          onPress: (complete, item) {
+            print(item.text);
+            complete();
+          },
+          onItemPress: (complete, item, index) {
+            print("Tapped image index: $index");
+            complete();
+          },
+        ),
+      ],
+    ),
+  ],
+);
+```
+
+Use `CPListImageRowItem.getMaximumNumberOfGridImages()` if you want to respect the host limit before building the row.
 
 ### Point Of Interest Template
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 1.3.x   | :white_check_mark: |
 | 1.2.x   | :white_check_mark: |
 | 1.1.x   | :white_check_mark: |
 | < 1.1   | :x:                |

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_carplay
 description: Flutter Apps are now on Apple CarPlay and Android Auto. This package aims to make it safe to use apps made with Flutter in the car by integrating with CarPlay or Android Auto.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/oguzhnatly/flutter_carplay#readme
 repository: https://github.com/oguzhnatly/flutter_carplay
 issue_tracker: https://github.com/oguzhnatly/flutter_carplay/issues


### PR DESCRIPTION
## Summary
- add 1.3.1 release notes to the README and changelog
- document the missing 1.3.0 APIs in the README
- update SECURITY supported versions to include 1.3.x
- bump package metadata to 1.3.1

## Why
1.3.0 is already out, so these follow ups should be framed as 1.3.1 work instead of more 1.3.0 notes.