### PR TITLE
feature/add-android-list-and-section-properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,8 +404,10 @@ await FlutterCarplay.setRootTemplate(
               CPListItem(
                 text: "Item 1",
                 detailText: "Detail Text",
+                accessoryImage: 'images/logo_flutter_1080px_clr.png',
                 onPress: (complete, self) {
                   self.setDetailText("You can change the detail text.. 🚀");
+                  self.setAccessoryImage('images/logo_flutter_1080px_clr.png');
                   Future.delayed(const Duration(seconds: 1), () {
                     self.setDetailText("Customizable Detail Text");
                     complete();
@@ -430,6 +432,54 @@ _flutterCarplay.forceUpdateRootTemplate();
 > You can set a root template without initializing the CarPlay Controllers, but some callback functions may not work or most likely you will get an error.
 
 > It's recommended that you should set the root template in the first initState of your app.
+
+### Basic Usage for Android Auto
+
+Android Auto row/list affordances follow the AndroidX Car App API names. Selectable lists render radio buttons on every row, `isBrowsable` renders the system navigation affordance, and `toggle` renders a switch in the row.
+
+```dart
+final FlutterAndroidAuto flutterAndroidAuto = FlutterAndroidAuto();
+
+await FlutterAndroidAuto.setRootTemplate(
+  template: AAListTemplate(
+    title: 'Home',
+    sections: [
+      AAListSection(
+        selectedIndex: 0,
+        onSelected: (selectedIndex, selectedItem) {
+          print('Selected $selectedIndex: ${selectedItem.title}');
+        },
+        items: [
+          AAListItem(title: 'Radio option 1'),
+          AAListItem(title: 'Radio option 2'),
+        ],
+      ),
+      AAListSection(
+        title: 'Rows',
+        items: [
+          AAListItem(
+            title: 'Open details',
+            isBrowsable: true,
+            onPress: (complete, item) {
+              complete();
+            },
+          ),
+          AAListItem(
+            title: 'Toggle item',
+            toggle: AAToggle(
+              isChecked: true,
+              onCheckedChange: (checked, item) {
+                print('${item.title}: $checked');
+              },
+            ),
+          ),
+        ],
+      ),
+    ],
+  ),
+);
+flutterAndroidAuto.forceUpdateRootTemplate();
+```
 
 ### Listen Connection Changes
 
@@ -749,6 +799,7 @@ final CPListTemplate listTemplate = CPListTemplate(
             complete();
           },
           image: 'images/logo_flutter_1080px_clr.png',
+          accessoryImage: 'images/logo_flutter_1080px_clr.png',
         ),
         CPListItem(
           text: "Item 2",

--- a/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FAAEnums.kt
+++ b/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FAAEnums.kt
@@ -15,5 +15,8 @@ enum class FAAChannelTypes {
     popToRootTemplate,
     onListItemSelected,
     onListItemSelectedComplete,
+    updateListTemplateSections,
+    onListSectionSelected,
+    onToggleCheckedChange,
     onScreenBackButtonPressed,
 }

--- a/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FlutterAndroidAutoPlugin.kt
+++ b/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FlutterAndroidAutoPlugin.kt
@@ -9,6 +9,7 @@ import androidx.car.app.model.ListTemplate
 import androidx.car.app.model.SectionedItemList
 import androidx.car.app.model.Row
 import androidx.car.app.model.Template
+import androidx.car.app.model.Toggle
 import androidx.car.app.Screen
 import androidx.car.app.ScreenManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -34,6 +35,10 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
         var events: EventChannel.EventSink? = null
         var currentTemplate: Template? = null
         var currentScreen: Screen? = null
+        private var currentRootTemplateElementId: String? = null
+        private val listTemplateData = mutableMapOf<String, MutableMap<String, Any?>>()
+        private val listTemplateBackButtons = mutableMapOf<String, Boolean>()
+        private val listTemplateScreens = mutableMapOf<String, Screen>()
 
         fun sendEvent(type: String, data: Map<String, Any>) {
             events?.success(
@@ -85,6 +90,10 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
                     )
 
                     FAAChannelTypes.popToRootTemplate.name -> popToRootTemplate(
+                        call, result
+                    )
+
+                    FAAChannelTypes.updateListTemplateSections.name -> updateListTemplateSections(
                         call, result
                     )
 
@@ -157,6 +166,37 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
         result.success(true)
     }
 
+    private fun updateListTemplateSections(
+        call: MethodCall, result: MethodChannel.Result
+    ) {
+        val elementId = call.argument<String>("elementId") ?: ""
+        val sections = call.argument<List<Map<String, Any?>>>("sections") ?: emptyList()
+        val data = listTemplateData[elementId]
+
+        if (data == null) {
+            result.error(
+                "No template found",
+                "AAListTemplate not found with elementId: $elementId",
+                null
+            )
+            return
+        }
+
+        data["sections"] = sections
+        val addBackButton = listTemplateBackButtons[elementId] ?: true
+
+        pluginScope.launch {
+            val template = getListTemplate(data, addBackButton)
+            listTemplateData[elementId] = data
+            if (currentRootTemplateElementId == elementId) {
+                currentTemplate = template
+            }
+            listTemplateScreens[elementId]?.invalidate()
+            currentScreen?.invalidate()
+            result.success(true)
+        }
+    }
+
     private fun pushTemplate(
         call: MethodCall, result: MethodChannel.Result
     ) {
@@ -169,9 +209,7 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
 
         pluginScope.launch {
             val template = when (runtimeType) {
-                "FAAListTemplate" -> getListTemplate(
-                    call, result, data
-                )
+                "FAAListTemplate" -> getListTemplate(data)
 
                 else -> null
             }
@@ -183,7 +221,10 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
                 )
             } else {
                 val newScreen = object : Screen(carContext) {
-                    override fun onGetTemplate(): Template = template
+                    override fun onGetTemplate(): Template =
+                        listTemplateData[elementId]?.let {
+                            getListTemplateBlocking(it, true)
+                        } ?: template
 
                     init {
                         lifecycle.addObserver(object : LifecycleEventObserver {
@@ -205,6 +246,10 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
                     }
                 }
 
+                listTemplateData[elementId] = data.toMutableMap()
+                listTemplateBackButtons[elementId] = true
+                listTemplateScreens[elementId] = newScreen
+
                 carContext.getCarService(ScreenManager::class.java)
                     .push(newScreen)
 
@@ -221,9 +266,7 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
 
         pluginScope.launch {
             val template = when (runtimeType) {
-                "FAAListTemplate" -> getListTemplate(
-                    call, result, data, false
-                )
+                "FAAListTemplate" -> getListTemplate(data, false)
 
                 else -> null
             }
@@ -236,6 +279,11 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
                 )
             } else {
                 currentTemplate = template
+                val elementId = data["_elementId"] as? String ?: ""
+                currentRootTemplateElementId = elementId
+                listTemplateData[elementId] = data.toMutableMap()
+                listTemplateBackButtons[elementId] = false
+                currentScreen?.let { listTemplateScreens[elementId] = it }
                 currentScreen?.invalidate()
                 result.success(true)
             }
@@ -243,37 +291,48 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
     }
 
     private suspend fun getListTemplate(
-        call: MethodCall,
-        result: MethodChannel.Result,
         data: Map<String, Any?>,
         addBackButton: Boolean = true
     ): Template {
-        val template = FAAListTemplate.fromJson(data)
-        val listTemplateBuilder =
-            ListTemplate.Builder().setTitle(template.title)
+        return createListTemplate(data, addBackButton)
+    }
 
-        if (template.sections.size == 0) {
+    private fun getListTemplateBlocking(
+        data: Map<String, Any?>,
+        addBackButton: Boolean = true
+    ): Template {
+        return kotlinx.coroutines.runBlocking {
+            createListTemplate(data, addBackButton)
+        }
+    }
+
+    private suspend fun createListTemplate(
+        data: Map<String, Any?>,
+        addBackButton: Boolean = true
+    ): Template {
+        val title = data["title"] as? String ?: ""
+        val sections = (data["sections"] as? List<*>)?.mapNotNull {
+            (it as? Map<*, *>)?.mapKeys { entry -> entry.key.toString() }
+                ?.let { FAAListSection.fromJson(it) }
+        } ?: emptyList()
+        val listTemplateBuilder =
+            ListTemplate.Builder().setTitle(title)
+
+        if (sections.isEmpty()) {
             listTemplateBuilder.setLoading(true)
         } else {
             listTemplateBuilder.setLoading(false)
             val isSingleList =
-                template.sections.size == 1 && template.sections.first().title.isEmpty()
+                sections.size == 1 && sections.first().title.isEmpty()
 
             if (isSingleList) {
-                val itemListBuilder = ItemList.Builder()
-                val sectionItems = template.sections.first().items
-                for (item in sectionItems) {
-                    itemListBuilder.addItem(createRowFromItem(item))
-                }
-                listTemplateBuilder.setSingleList(itemListBuilder.build())
+                listTemplateBuilder.setSingleList(
+                    createItemListFromSection(sections.first())
+                )
             } else {
-                for (section in template.sections) {
-                    val itemListBuilder = ItemList.Builder()
-                    for (item in section.items) {
-                        itemListBuilder.addItem(createRowFromItem(item))
-                    }
+                for (section in sections) {
                     val sectionedItemList = SectionedItemList.create(
-                        itemListBuilder.build(), section.title ?: ""
+                        createItemListFromSection(section), section.title ?: ""
                     )
                     listTemplateBuilder.addSectionedList(sectionedItemList)
                 }
@@ -287,8 +346,45 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
         return listTemplateBuilder.build()
     }
 
+    private suspend fun createItemListFromSection(section: FAAListSection): ItemList {
+        val itemListBuilder = ItemList.Builder()
+        val useSelectionListener =
+            section.isOnSelectedListenerActive || section.selectedIndex != null
+
+        for (item in section.items) {
+            itemListBuilder.addItem(
+                createRowFromItem(item, enableOnClick = !useSelectionListener)
+            )
+        }
+
+        if (useSelectionListener) {
+            itemListBuilder.setOnSelectedListener { selectedIndex ->
+                if (section.isOnSelectedListenerActive) {
+                    sendEvent(
+                        type = FAAChannelTypes.onListSectionSelected.name,
+                        data = mapOf(
+                            "elementId" to section.elementId,
+                            "selectedIndex" to selectedIndex
+                        )
+                    )
+                }
+            }
+        }
+
+        section.selectedIndex?.let { selectedIndex ->
+            if (selectedIndex >= 0 && selectedIndex < section.items.size) {
+                itemListBuilder.setSelectedIndex(selectedIndex)
+            }
+        }
+
+        return itemListBuilder.build()
+    }
+
     // Helper function to create a Row from an FAAListItem, avoiding code duplication
-    private suspend fun createRowFromItem(item: FAAListItem): Row {
+    private suspend fun createRowFromItem(
+        item: FAAListItem,
+        enableOnClick: Boolean = true
+    ): Row {
         val rowBuilder = Row.Builder().setTitle(CarText.create(item.title))
 
         item.subtitle?.let { rowBuilder.addText(CarText.create(it)) }
@@ -299,7 +395,28 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
             }
         }
 
-        if (item.isOnPressListenerActive) {
+        item.isBrowsable?.let {
+            rowBuilder.setBrowsable(it)
+        }
+
+        item.toggle?.let { toggle ->
+            val toggleBuilder = Toggle.Builder { checked ->
+                if (toggle.isOnCheckedChangeListenerActive) {
+                    sendEvent(
+                        type = FAAChannelTypes.onToggleCheckedChange.name,
+                        data = mapOf(
+                            "elementId" to item.elementId,
+                            "checked" to checked
+                        )
+                    )
+                }
+            }.setChecked(toggle.isChecked)
+
+            toggle.isEnabled?.let { toggleBuilder.setEnabled(it) }
+            rowBuilder.setToggle(toggleBuilder.build())
+        }
+
+        if (enableOnClick && item.isOnPressListenerActive) {
             rowBuilder.setOnClickListener {
                 sendEvent(
                     type = FAAChannelTypes.onListItemSelected.name,

--- a/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/models/list/FAAListItem.kt
+++ b/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/models/list/FAAListItem.kt
@@ -5,6 +5,8 @@ data class FAAListItem(
     val title: String,
     val subtitle: String? = null,
     val imageUrl: String? = null,
+    val isBrowsable: Boolean? = null,
+    val toggle: FAAToggle? = null,
     val isOnPressListenerActive: Boolean,
 ) {
     companion object {
@@ -13,10 +15,33 @@ data class FAAListItem(
             val title = map["title"] as? String ?: ""
             val subtitle = map["subtitle"] as? String
             val imageUrl = map["imageUrl"] as? String
+            val isBrowsable = map["isBrowsable"] as? Boolean
+            val toggle = (map["toggle"] as? Map<*, *>)?.mapKeys { entry ->
+                entry.key.toString()
+            }?.let { FAAToggle.fromJson(it) }
             val isOnPressListenerActive = map["onPress"] as? Boolean ?: false
 
             return FAAListItem(
-                elementId, title, subtitle, imageUrl, isOnPressListenerActive
+                elementId, title, subtitle, imageUrl, isBrowsable, toggle, isOnPressListenerActive
+            )
+        }
+    }
+}
+
+data class FAAToggle(
+    val isChecked: Boolean = false,
+    val isEnabled: Boolean? = null,
+    val isOnCheckedChangeListenerActive: Boolean = false,
+) {
+    companion object {
+        fun fromJson(map: Map<String, Any?>): FAAToggle {
+            val isChecked = map["isChecked"] as? Boolean ?: false
+            val isEnabled = map["isEnabled"] as? Boolean
+            val isOnCheckedChangeListenerActive =
+                map["onCheckedChange"] as? Boolean ?: false
+
+            return FAAToggle(
+                isChecked, isEnabled, isOnCheckedChangeListenerActive
             )
         }
     }

--- a/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/models/list/FAAListSection.kt
+++ b/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/models/list/FAAListSection.kt
@@ -4,6 +4,8 @@ data class FAAListSection(
     val elementId: String,
     val title: String,
     val items: List<FAAListItem>,
+    val selectedIndex: Int? = null,
+    val isOnSelectedListenerActive: Boolean = false,
 ) {
     companion object {
         fun fromJson(map: Map<String, Any?>): FAAListSection {
@@ -13,8 +15,13 @@ data class FAAListSection(
                 (it as? Map<*, *>)?.mapKeys { entry -> entry.key.toString() }
                     ?.let { FAAListItem.fromJson(it) }
             } ?: emptyList()
+            val selectedIndex = map["selectedIndex"] as? Int
+            val isOnSelectedListenerActive =
+                map["onSelected"] as? Boolean ?: false
 
-            return FAAListSection(elementId, title, items)
+            return FAAListSection(
+                elementId, title, items, selectedIndex, isOnSelectedListenerActive
+            )
         }
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,6 +55,7 @@ class _MyAppState extends State<MyApp> {
             });
           },
           image: 'images/logo_flutter_1080px_clr.png',
+          accessoryImage: 'images/logo_flutter_1080px_clr.png',
         ),
         CPListItem(
           text: 'Item 2',
@@ -212,6 +213,7 @@ class _MyAppState extends State<MyApp> {
               AAListItem(
                 title: 'Page 1',
                 subtitle: 'Click to open page 1',
+                isBrowsable: true,
                 onPress: (complete, AAListItem item) {
                   print('Item for Page 1 pressed');
                   FlutterAndroidAuto.push(
@@ -286,8 +288,27 @@ class _MyAppState extends State<MyApp> {
           ),
           AAListSection(
             title: 'Second Section',
+            selectedIndex: 0,
+            onSelected: (selectedIndex, selectedItem) {
+              print('Selected index: $selectedIndex (${selectedItem.title})');
+            },
             items: [
-              AAListItem(title: 'Test'),
+              AAListItem(title: 'Radio option 1'),
+              AAListItem(title: 'Radio option 2'),
+            ],
+          ),
+          AAListSection(
+            title: 'Toggles',
+            items: [
+              AAListItem(
+                title: 'Toggle item',
+                toggle: AAToggle(
+                  isChecked: true,
+                  onCheckedChange: (checked, item) {
+                    print('${item.title} changed to $checked');
+                  },
+                ),
+              ),
             ],
           ),
         ],

--- a/ios/Classes/models/list/FCPListItem.swift
+++ b/ios/Classes/models/list/FCPListItem.swift
@@ -16,6 +16,7 @@ final class FCPListItem {
   private var isOnPressListenerActive: Bool = false
   private var completeHandler: (() -> Void)?
   private var image: String?
+  private var accessoryImage: String?
   private var playbackProgress: CGFloat?
   private var isPlaying: Bool?
   private var playingIndicatorLocation: CPListItemPlayingIndicatorLocation?
@@ -27,6 +28,7 @@ final class FCPListItem {
     self.detailText = obj["detailText"] as? String
     self.isOnPressListenerActive = obj["onPress"] as? Bool ?? false
     self.image = obj["image"] as? String
+    self.accessoryImage = obj["accessoryImage"] as? String
     self.playbackProgress = obj["playbackProgress"] as? CGFloat
     self.isPlaying = obj["isPlaying"] as? Bool
     self.setPlayingIndicatorLocation(fromString: obj["playingIndicatorLocation"] as? String)
@@ -60,6 +62,15 @@ final class FCPListItem {
         }
       }
     }
+    if accessoryImage != nil {
+      listItem.setAccessoryImage(makeSafeUIPlaceholder())
+      let imageSource = self.accessoryImage!.toImageSource()
+      loadUIImageAsync(from: imageSource) { uiImage in
+        if let uiImage = uiImage {
+          listItem.setAccessoryImage(uiImage)
+        }
+      }
+    }
     if playbackProgress != nil {
       listItem.playbackProgress = playbackProgress!
     }
@@ -89,6 +100,7 @@ final class FCPListItem {
     let text = args["text"] as? String
     let detailText = args["detailText"] as? String
     let image = args["image"] as? String
+    let accessoryImage = args["accessoryImage"] as? String
     let playbackProgress = args["playbackProgress"] as? CGFloat
     let isPlaying = args["isPlaying"] as? Bool
     let playingIndicatorLocation = args["playingIndicatorLocation"] as? String
@@ -115,6 +127,20 @@ final class FCPListItem {
     } else if image == nil {
       self.image = nil
       self._super?.setImage(nil)
+    }
+
+    if let accessoryImage = accessoryImage, accessoryImage != self.accessoryImage {
+      self._super?.setAccessoryImage(makeSafeUIPlaceholder())
+      let imageSource = accessoryImage.toImageSource()
+      loadUIImageAsync(from: imageSource) { uiImage in
+        if let uiImage = uiImage {
+          self._super?.setAccessoryImage(uiImage)
+        }
+      }
+      self.accessoryImage = accessoryImage
+    } else if accessoryImage == nil && args.keys.contains("accessoryImage") {
+      self.accessoryImage = nil
+      self._super?.setAccessoryImage(nil)
     }
 
     if playbackProgress != nil {

--- a/lib/aa_models/list/list_item.dart
+++ b/lib/aa_models/list/list_item.dart
@@ -1,5 +1,23 @@
 import 'package:uuid/uuid.dart';
 
+class AAToggle {
+  final bool isChecked;
+  final bool? isEnabled;
+  final Function(bool checked, AAListItem self)? onCheckedChange;
+
+  const AAToggle({
+    this.isChecked = false,
+    this.isEnabled,
+    this.onCheckedChange,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'isChecked': isChecked,
+        'isEnabled': isEnabled,
+        'onCheckedChange': onCheckedChange != null ? true : false,
+      };
+}
+
 class AAListItem {
   /// Unique id of the object.
   final String _elementId;
@@ -7,14 +25,30 @@ class AAListItem {
   final String title;
   final String? subtitle;
   final String? imageUrl;
+  final bool? isBrowsable;
+  final AAToggle? toggle;
   final Function(Function() complete, AAListItem self)? onPress;
 
   AAListItem({
     required this.title,
     this.subtitle,
     this.imageUrl,
+    this.isBrowsable,
+    this.toggle,
     this.onPress,
-  }) : _elementId = const Uuid().v4();
+  })  : assert(
+          isBrowsable != true || toggle == null,
+          'A browsable row must not have a toggle set.',
+        ),
+        assert(
+          isBrowsable != true || onPress != null,
+          'A browsable row must have an onClickListener set.',
+        ),
+        assert(
+          toggle == null || onPress == null,
+          'If a row contains a toggle, it must not have an onClickListener set.',
+        ),
+        _elementId = const Uuid().v4();
 
   String get uniqueId => _elementId;
 
@@ -23,6 +57,8 @@ class AAListItem {
         'title': title,
         'subtitle': subtitle,
         'imageUrl': imageUrl,
+        'isBrowsable': isBrowsable,
+        'toggle': toggle?.toJson(),
         'onPress': onPress != null ? true : false,
       };
 }

--- a/lib/aa_models/list/list_item.dart
+++ b/lib/aa_models/list/list_item.dart
@@ -1,11 +1,11 @@
 import 'package:uuid/uuid.dart';
 
 class AAToggle {
-  final bool isChecked;
+  bool isChecked;
   final bool? isEnabled;
   final Function(bool checked, AAListItem self)? onCheckedChange;
 
-  const AAToggle({
+  AAToggle({
     this.isChecked = false,
     this.isEnabled,
     this.onCheckedChange,

--- a/lib/aa_models/list/list_section.dart
+++ b/lib/aa_models/list/list_section.dart
@@ -10,11 +10,34 @@ class AAListSection {
   final String? title;
 
   final List<AAListItem> items;
+  final int? selectedIndex;
+  final Function(int selectedIndex, AAListItem selectedItem)? onSelected;
 
   AAListSection({
     this.title,
     required this.items,
-  }) : _elementId = const Uuid().v4();
+    this.selectedIndex,
+    this.onSelected,
+  })  : assert(
+          selectedIndex == null ||
+              (selectedIndex >= 0 && selectedIndex < items.length),
+          'selectedIndex must be within the list item range.',
+        ),
+        assert(
+          (selectedIndex == null && onSelected == null) || items.isNotEmpty,
+          'A selectable list must have at least one item.',
+        ),
+        assert(
+          selectedIndex == null && onSelected == null ||
+              items.every((AAListItem item) => item.onPress == null),
+          'Selectable list items must not have an onClickListener set.',
+        ),
+        assert(
+          selectedIndex == null && onSelected == null ||
+              items.every((AAListItem item) => item.toggle == null),
+          'Selectable list items must not have a toggle set.',
+        ),
+        _elementId = const Uuid().v4();
 
   String get uniqueId => _elementId;
 
@@ -22,5 +45,7 @@ class AAListSection {
         '_elementId': _elementId,
         'title': title,
         'items': items.map((AAListItem item) => item.toJson()).toList(),
+        'selectedIndex': selectedIndex,
+        'onSelected': onSelected != null ? true : false,
       };
 }

--- a/lib/aa_models/list/list_section.dart
+++ b/lib/aa_models/list/list_section.dart
@@ -10,7 +10,7 @@ class AAListSection {
   final String? title;
 
   final List<AAListItem> items;
-  final int? selectedIndex;
+  int? selectedIndex;
   final Function(int selectedIndex, AAListItem selectedItem)? onSelected;
 
   AAListSection({

--- a/lib/aa_models/list/list_template.dart
+++ b/lib/aa_models/list/list_template.dart
@@ -25,4 +25,11 @@ class AAListTemplate implements AATemplate {
         'sections':
             sections.map((AAListSection section) => section.toJson()).toList(),
       };
+
+  void updateSections(List<AAListSection> newSections) {
+    final copy = List<AAListSection>.from(newSections);
+    sections
+      ..clear()
+      ..addAll(copy);
+  }
 }

--- a/lib/android_auto_worker.dart
+++ b/lib/android_auto_worker.dart
@@ -58,6 +58,18 @@ class FlutterAndroidAuto {
             event['data']['elementId'],
           );
           break;
+        case FAAChannelTypes.onListSectionSelected:
+          _androidAutoController.processFAAListSectionSelectedChannel(
+            event['data']['elementId'],
+            event['data']['selectedIndex'],
+          );
+          break;
+        case FAAChannelTypes.onToggleCheckedChange:
+          _androidAutoController.processFAAToggleCheckedChangeChannel(
+            event['data']['elementId'],
+            event['data']['checked'],
+          );
+          break;
         case FAAChannelTypes.onScreenBackButtonPressed:
           FlutterAndroidAutoController.templateHistory.removeWhere(
             (AATemplate item) => item.uniqueId == event['data']['elementId'],
@@ -126,6 +138,17 @@ class FlutterAndroidAuto {
         FlutterAndroidAutoController.templateHistory[0] = template;
       }
     }
+  }
+
+  /// It will update the sections of the [AAListTemplate] which has the given [elementId].
+  Future<void> updateListTemplateSections({
+    required String elementId,
+    required List<AAListSection> sections,
+  }) {
+    return FlutterAndroidAutoController.updateAAListTemplateSections(
+      elementId: elementId,
+      sections: sections,
+    );
   }
 
   /// It will set the current root template again.

--- a/lib/constants/private_constants.dart
+++ b/lib/constants/private_constants.dart
@@ -42,5 +42,8 @@ enum FAAChannelTypes {
   popToRootTemplate,
   onListItemSelected,
   onListItemSelectedComplete,
+  updateListTemplateSections,
+  onListSectionSelected,
+  onToggleCheckedChange,
   onScreenBackButtonPressed,
 }

--- a/lib/controllers/android_auto_controller.dart
+++ b/lib/controllers/android_auto_controller.dart
@@ -2,6 +2,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_carplay/constants/private_constants.dart';
 
 import '../aa_models/list/list_item.dart';
+import '../aa_models/list/list_section.dart';
+import '../aa_models/list/list_template.dart';
 import '../aa_models/template.dart';
 import '../helpers/auto_android_helper.dart';
 
@@ -85,6 +87,40 @@ class FlutterAndroidAutoController {
     });
   }*/
 
+  static Future<bool?> flutterToNativeModuleStatic(
+    FAAChannelTypes type, [
+    dynamic data,
+  ]) async {
+    final bool? value = await _methodChannel.invokeMethod<bool>(
+      type.name,
+      data,
+    );
+    return value;
+  }
+
+  static Future<void> updateAAListTemplateSections({
+    required String elementId,
+    required List<AAListSection> sections,
+  }) async {
+    final bool? isCompleted = await flutterToNativeModuleStatic(
+      FAAChannelTypes.updateListTemplateSections,
+      <String, dynamic>{
+        'elementId': elementId,
+        'sections':
+            sections.map((AAListSection section) => section.toJson()).toList(),
+      },
+    );
+
+    if (isCompleted == true) {
+      for (final template in templateHistory) {
+        if (template is AAListTemplate && template.uniqueId == elementId) {
+          template.updateSections(sections);
+          return;
+        }
+      }
+    }
+  }
+
   void processFAAListItemSelectedChannel(String elementId) {
     final AAListItem? listItem = _androidAutoHelper.findAAListItem(
       templates: templateHistory,
@@ -98,6 +134,33 @@ class FlutterAndroidAutoController {
         ),
         listItem,
       );
+    }
+  }
+
+  void processFAAListSectionSelectedChannel(
+      String elementId, int selectedIndex) {
+    final AAListSection? listSection = _androidAutoHelper.findAAListSection(
+      templates: templateHistory,
+      elementId: elementId,
+    );
+    final selectedItem = listSection?.items.elementAtOrNull(selectedIndex);
+
+    if (listSection != null && selectedItem != null) {
+      listSection.onSelected?.call(selectedIndex, selectedItem);
+    }
+  }
+
+  void processFAAToggleCheckedChangeChannel(
+    String elementId,
+    bool checked,
+  ) {
+    final AAListItem? listItem = _androidAutoHelper.findAAListItem(
+      templates: templateHistory,
+      elementId: elementId,
+    );
+
+    if (listItem != null) {
+      listItem.toggle?.onCheckedChange?.call(checked, listItem);
     }
   }
 

--- a/lib/controllers/android_auto_controller.dart
+++ b/lib/controllers/android_auto_controller.dart
@@ -146,6 +146,7 @@ class FlutterAndroidAutoController {
     final selectedItem = listSection?.items.elementAtOrNull(selectedIndex);
 
     if (listSection != null && selectedItem != null) {
+      listSection.selectedIndex = selectedIndex;
       listSection.onSelected?.call(selectedIndex, selectedItem);
     }
   }
@@ -160,7 +161,11 @@ class FlutterAndroidAutoController {
     );
 
     if (listItem != null) {
-      listItem.toggle?.onCheckedChange?.call(checked, listItem);
+      final toggle = listItem.toggle;
+      if (toggle != null) {
+        toggle.isChecked = checked;
+        toggle.onCheckedChange?.call(checked, listItem);
+      }
     }
   }
 

--- a/lib/helpers/auto_android_helper.dart
+++ b/lib/helpers/auto_android_helper.dart
@@ -32,6 +32,28 @@ class FlutterAutoAndroidHelper {
     return null;
   }
 
+  AAListSection? findAAListSection({
+    required List<AATemplate> templates,
+    required String elementId,
+  }) {
+    for (var t in templates) {
+      final List<AAListTemplate> listTemplates = [];
+
+      if (t is AAListTemplate) {
+        listTemplates.add(t);
+      }
+
+      for (var list in listTemplates) {
+        for (var section in list.sections) {
+          if (section.uniqueId == elementId) {
+            return section;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
   String makeFAAChannelId({String event = ''}) =>
       'com.oguzhnatly.flutter_android_auto$event';
 }

--- a/lib/models/list/list_item.dart
+++ b/lib/models/list/list_item.dart
@@ -24,6 +24,15 @@ class CPListItem extends CPListTemplateItem {
   /// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
   String? image;
 
+  /// The image that the list item displays in its trailing region.
+  ///
+  /// Supports three formats:
+  /// - **Asset path**: `images/flutter_logo.png` (from pubspec.yaml assets)
+  /// - **File path**: `file:///path/to/image.png` (local file on device)
+  /// - **Network URL**: `https://example.com/image.png` (remote image)
+  /// iOS 14.0+ | iPadOS 14.0+ | Mac Catalyst 14.0+
+  String? accessoryImage;
+
   /// The playback progress status for the content that the list item represents.
   /// iOS 14.0+ | iPadOS 14.0+ | Mac Catalyst 14.0+
   double? playbackProgress;
@@ -54,6 +63,7 @@ class CPListItem extends CPListTemplateItem {
     this.detailText,
     this.onPress,
     this.image,
+    this.accessoryImage,
     this.playbackProgress,
     this.isPlaying,
     this.playingIndicatorLocation,
@@ -68,6 +78,7 @@ class CPListItem extends CPListTemplateItem {
         'detailText': detailText,
         'onPress': onPress != null ? true : false,
         'image': image,
+        'accessoryImage': accessoryImage,
         'playbackProgress': playbackProgress,
         'isPlaying': isPlaying,
         'playingIndicatorLocation': playingIndicatorLocation?.name,
@@ -95,6 +106,14 @@ class CPListItem extends CPListTemplateItem {
   /// - **Network URL**: `https://example.com/image.png` (remote image)
   void setImage(String image) {
     this.image = image;
+    FlutterCarPlayController.updateCPListItem(this);
+  }
+
+  /// Updating the image displayed in the trailing region of the list item cell.
+  ///
+  /// Supports the same asset path, file path, and network URL formats as [image].
+  void setAccessoryImage(String? accessoryImage) {
+    this.accessoryImage = accessoryImage;
     FlutterCarPlayController.updateCPListItem(this);
   }
 
@@ -133,6 +152,7 @@ class CPListItem extends CPListTemplateItem {
     String? text,
     String? detailText,
     String? image,
+    String? accessoryImage,
     double? playbackProgress,
     bool? isPlaying,
     CPListItemPlayingIndicatorLocation? playingIndicatorLocation,
@@ -141,6 +161,7 @@ class CPListItem extends CPListTemplateItem {
     if (text != null) this.text = text;
     if (detailText != null) this.detailText = detailText;
     if (image != null) this.image = image;
+    if (accessoryImage != null) this.accessoryImage = accessoryImage;
     if (playbackProgress != null) {
       if (playbackProgress >= 0.0 && playbackProgress <= 1.0) {
         this.playbackProgress = playbackProgress;


### PR DESCRIPTION
## Summary
- Adds native-shaped list indicator APIs: `CPListItem.accessoryImage` for CarPlay and Android Auto `selectedIndex` / `onSelected`, `isBrowsable`, and `AAToggle` support.
- Wires Android Auto native rendering and events for selectable `ItemList`s, browsable rows, row toggles, and list-section updates.
- Updates the example app and README with usage for CarPlay accessory images and Android Auto radio-list, browsable-row, and toggle visuals.