### PR TITLE
feat: expose onPop callback on push templates

### DIFF
--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -95,9 +95,14 @@ class FlutterCarplay {
           );
           break;
         case FCPChannelTypes.onScreenBackButtonPressed:
-          FlutterCarPlayController.templateHistory.removeWhere(
-            (CPTemplate item) => item.uniqueId == event['data']['elementId'],
-          );
+          final String elementId = event['data']['elementId'];
+          final CPTemplate? poppedTemplate = FlutterCarPlayController
+              .templateHistory
+              .where((item) => item.uniqueId == elementId)
+              .firstOrNull;
+          poppedTemplate?.onPop?.call();
+          FlutterCarPlayController.templateHistory
+              .removeWhere((item) => item.uniqueId == elementId);
           break;
         default:
           break;

--- a/lib/models/grid/grid_template.dart
+++ b/lib/models/grid/grid_template.dart
@@ -28,6 +28,7 @@ class CPGridTemplate extends CPTemplate {
     super.tabTitle,
     super.showsTabBadge = false,
     super.systemIcon,
+    super.onPop,
     String? id,
   }) : _elementId = id ?? const Uuid().v4();
 

--- a/lib/models/information/information_template.dart
+++ b/lib/models/information/information_template.dart
@@ -37,6 +37,7 @@ class CPInformationTemplate extends CPTemplate {
     super.tabTitle,
     super.showsTabBadge = false,
     super.systemIcon,
+    super.onPop,
     String? id,
   }) : _elementId = id ?? const Uuid().v4();
 

--- a/lib/models/list/list_template.dart
+++ b/lib/models/list/list_template.dart
@@ -46,6 +46,7 @@ class CPListTemplate extends CPTemplate {
     super.tabTitle,
     super.showsTabBadge = false,
     super.systemIcon,
+    super.onPop,
     this.backButton,
     String? id,
   }) : _elementId = id ?? const Uuid().v4();

--- a/lib/models/poi/poi_template.dart
+++ b/lib/models/poi/poi_template.dart
@@ -25,6 +25,7 @@ class CPPointOfInterestTemplate extends CPTemplate {
     super.tabTitle,
     super.showsTabBadge = false,
     super.systemIcon,
+    super.onPop,
     String? id,
   }) : _elementId = id ?? const Uuid().v4();
 

--- a/lib/models/tabbar/tabbar_template.dart
+++ b/lib/models/tabbar/tabbar_template.dart
@@ -36,6 +36,7 @@ class CPTabBarTemplate extends CPTemplate {
     super.tabTitle,
     super.showsTabBadge = false,
     super.systemIcon,
+    super.onPop,
     String? id,
   })  : templates = List<CPTemplate>.from(templates),
         _elementId = id ?? const Uuid().v4();

--- a/lib/models/template.dart
+++ b/lib/models/template.dart
@@ -1,12 +1,15 @@
+import 'package:flutter/foundation.dart';
+
 import 'alert/alert_action.dart';
 
 /// https://developer.apple.com/documentation/carplay/cptemplate
 /// iOS 12.0+ | iPadOS 12.0+ | Mac Catalyst 13.1+
 abstract class CPTemplate {
-  const CPTemplate({
+  CPTemplate({
     this.tabTitle,
     this.showsTabBadge = false,
     this.systemIcon,
+    this.onPop,
   });
 
   /// An indicator you use to call attention to the tab.
@@ -23,6 +26,17 @@ abstract class CPTemplate {
   /// A short title that describes the content of the tab.
   /// iOS 14.0+ | iPadOS 14.0+ | Mac Catalyst 14.0+
   final String? tabTitle;
+
+  /// Called when this template is popped from the navigation stack.
+  ///
+  /// Fires for both user-initiated pops (CarPlay back button) and
+  /// programmatic pops via [FlutterCarplay.pop]. Useful for cleaning
+  /// up subscriptions, state listeners, or analytics events tied to
+  /// this template's lifetime.
+  ///
+  /// Not called for modal templates (alerts, action sheets) — those
+  /// have their own lifecycle hooks.
+  final VoidCallback? onPop;
 
   String get uniqueId;
 


### PR DESCRIPTION
  Summary

  - Adds onPop callback to CPTemplate base class, exposed on all push templates (CPListTemplate, CPGridTemplate, CPInformationTemplate, CPPointOfInterestTemplate, CPTabBarTemplate)
  - Fires the callback in carplay_worker.dart when onScreenBackButtonPressed is received, before removing the template from history
  - Useful for cleanup of subscriptions, state listeners, or analytics tied to a template's lifetime

  Motivation

  There was no way to react to a template being popped from the navigation stack. Apps commonly need to cancel listeners or track screen-exit events — this hook enables that without
   polling.

  Notes

  - onPop fires for both user-initiated pops (CarPlay back button) and programmatic pops via FlutterCarplay.pop
  - Not applicable to modal templates (alerts, action sheets) — those have their own lifecycle
  - CPTemplate constructor had to drop const to accommodate the VoidCallback field

  Test plan

  - Push a template with onPop set and verify callback fires on back button press
  - Verify callback fires on programmatic FlutterCarplay.pop()
  - Verify templates without onPop (null) behave unchanged
