### PR TITLE
Infinite loading spinner when same item ID appears in multiple CPTabBarTemplate tabs               

### DIFF
--- a/ios/Classes/SwiftFlutterCarplayPlugin.swift
+++ b/ios/Classes/SwiftFlutterCarplayPlugin.swift
@@ -464,6 +464,7 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
     elementId: String, actionWhenFound: (_ item: FCPListTemplateItem) -> Void
   ) {
     var collected: [FCPListTemplate] = []
+    var found = false
 
     for template in SwiftFlutterCarplayPlugin.templateStack {
       if let tabBar = template as? FCPTabBarTemplate {
@@ -478,7 +479,7 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
         for item in search.getCurrentResultItems() {
           if item.elementId == elementId {
             actionWhenFound(item)
-            return
+            found = true
           }
         }
       }
@@ -489,12 +490,15 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
         for i in s.getFCPListTemplateItems() {
           if i.elementId == elementId {
             actionWhenFound(i)
-            return
+            found = true
           }
         }
       }
     }
-    NSLog("FCP: FCPListTemplateItem not found with elementId: \(elementId)")
+
+    if !found {
+      NSLog("FCP: FCPListTemplateItem not found with elementId: \(elementId)")
+    }
   }
 
   @available(iOS 26.0, *)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_carplay
 description: Flutter Apps are now on Apple CarPlay and Android Auto. This package aims to make it safe to use apps made with Flutter in the car by integrating with CarPlay or Android Auto.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/oguzhnatly/flutter_carplay#readme
 repository: https://github.com/oguzhnatly/flutter_carplay
 issue_tracker: https://github.com/oguzhnatly/flutter_carplay/issues


### PR DESCRIPTION
Problem                                                                                                       
                                                                                                                  
  When using CPTabBarTemplate with multiple tabs where the same CPListItem ID is shared across tabs (e.g. a door  
  that appears in both a "Favorites" tab and an "All Doors" tab), tapping the item causes the loading spinner to  
  run indefinitely and never stop.                                                                                
                                                                                                                
  Root cause: findListItem in SwiftFlutterCarplayPlugin performs a linear search and returns on the first match.  
  When the same elementId exists in two tabs, two FCPListItem instances are created — each holding their own
  completeHandler. On tap, the native handler correctly stores the completion closure in the tapped instance.     
  However, when stopHandler() is eventually called, findListItem resolves to the first instance found (which was
  never tapped and has no completeHandler set), so the spinner on the actual tapped instance is never dismissed.

Reproduction                                                                                                  

  1. Create a CPTabBarTemplate with two tabs (e.g. Favorites and All Doors)                                       
  2. Have the same logical item (same id) appear in both tabs
  3. Tap the item in either tab                                                                                   
  4. Observe the loading spinner never stops                                                                    
  Video:
  https://github.com/user-attachments/assets/9f2b1a68-b9f5-463b-bb59-7f4f1ae12fa7


  Fix

  Remove the early return from findListItem so actionWhenFound is called on all instances sharing the same        
  elementId. stopHandler() already guards against a nil completeHandler, making non-tapped instances safe no-ops —
   only the instance that was actually tapped executes its completion.                                            
                                                                                                                
  This also fixes a secondary issue: updateListItem now correctly propagates updates to all tabs displaying an    
  item with the same ID.
                                                                                                                    
  Changes                                                                                                       

  - ios/Classes/SwiftFlutterCarplayPlugin.swift — removed early return from findListItem, iterates all matches    
  instead of stopping at the first