### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+## 1.6.1 - 2026-06-15
+
+- Fix Swift Package Manager builds by keeping `FCPSearchTemplate.swift` inside the SwiftPM source path (#123, #124) (ty @Gabriellsp)
+- Reject unsupported `CPSearchTemplate` root templates before CarPlay receives an invalid root template.
+
 ## 1.6.0 - 2026-06-13
 
 - Add Swift Package Manager support for iOS package consumers (#111) (ty @justinbeatz)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.6.0"
+    version: "1.6.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/ios/flutter_carplay/Sources/flutter_carplay/FlutterCarplayPluginSceneDelegate.swift
+++ b/ios/flutter_carplay/Sources/flutter_carplay/FlutterCarplayPluginSceneDelegate.swift
@@ -28,11 +28,28 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
 {
   static private var interfaceController: CPInterfaceController?
 
-  static public func forceUpdateRootTemplate() {
-    guard let rootTemplate = SwiftFlutterCarplayPlugin.rootTemplate else { return }
+  static public func forceUpdateRootTemplate(
+    completion: ((_ completed: Bool, _ error: Error?) -> Void)? = nil
+  ) {
+    guard let rootTemplate = SwiftFlutterCarplayPlugin.rootTemplate else {
+      completion?(true, nil)
+      return
+    }
     let animated = SwiftFlutterCarplayPlugin.animated
 
-    self.interfaceController?.setRootTemplate(rootTemplate, animated: animated)
+    guard let interfaceController = self.interfaceController else {
+      completion?(true, nil)
+      return
+    }
+
+    interfaceController.setRootTemplate(rootTemplate, animated: animated) { completed, error in
+      if let error = error {
+        NSLog(
+          "FlutterCarPlaySceneDelegate setRootTemplate failed: \(error.localizedDescription)"
+        )
+      }
+      completion?(completed, error)
+    }
   }
 
   // https://developer.apple.com/documentation/carplay/cplisttemplate/updatesections(_:)
@@ -164,11 +181,16 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     interfaceController.delegate = self
 
     SwiftFlutterCarplayPlugin.onCarplayConnectionChange(status: FCPConnectionTypes.connected)
-    let rootTemplate = SwiftFlutterCarplayPlugin.rootTemplate
-
-    if rootTemplate != nil {
-      FlutterCarPlaySceneDelegate.interfaceController?.setRootTemplate(
-        rootTemplate!, animated: SwiftFlutterCarplayPlugin.animated, completion: nil)
+    if let rootTemplate = SwiftFlutterCarplayPlugin.rootTemplate {
+      interfaceController.setRootTemplate(
+        rootTemplate, animated: SwiftFlutterCarplayPlugin.animated
+      ) { completed, error in
+        if let error = error {
+          NSLog(
+            "FlutterCarPlaySceneDelegate didConnect setRootTemplate failed: \(error.localizedDescription)"
+          )
+        }
+      }
     }
   }
 

--- a/ios/flutter_carplay/Sources/flutter_carplay/SwiftFlutterCarplayPlugin.swift
+++ b/ios/flutter_carplay/Sources/flutter_carplay/SwiftFlutterCarplayPlugin.swift
@@ -80,9 +80,6 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       case String(describing: FCPListTemplate.self):
         rootTemplate = FCPListTemplate(obj: data)
         break
-      case String(describing: FCPSearchTemplate.self):
-        rootTemplate = FCPSearchTemplate(obj: data)
-        break
       default:
         result(false)
         return
@@ -97,12 +94,14 @@ public class SwiftFlutterCarplayPlugin: NSObject, FlutterPlugin {
       SwiftFlutterCarplayPlugin.objcRootTemplate = rootTemplate!
       let animated = args["animated"] as! Bool
       SwiftFlutterCarplayPlugin.animated = animated
-      FlutterCarPlaySceneDelegate.forceUpdateRootTemplate()
-      result(true)
+      FlutterCarPlaySceneDelegate.forceUpdateRootTemplate { completed, error in
+        result(completed && error == nil)
+      }
       break
     case FCPChannelTypes.forceUpdateRootTemplate:
-      FlutterCarPlaySceneDelegate.forceUpdateRootTemplate()
-      result(true)
+      FlutterCarPlaySceneDelegate.forceUpdateRootTemplate { completed, error in
+        result(completed && error == nil)
+      }
       break
     case FCPChannelTypes.updateListTemplateSections:
       guard let args = call.arguments as? [String: Any] else {

--- a/lib/carplay_worker.dart
+++ b/lib/carplay_worker.dart
@@ -179,7 +179,8 @@ class FlutterCarplay {
   ///
   /// - rootTemplate is a template to use as the root of a new navigation hierarchy. If one exists,
   /// it will replace the current rootTemplate. **Must be one of the type:**
-  /// [CPTabBarTemplate], [CPGridTemplate], [CPListTemplate] If not, it will throw an [TypeError]
+  /// [CPTabBarTemplate], [CPGridTemplate], [CPListTemplate],
+  /// [CPInformationTemplate], [CPPointOfInterestTemplate] If not, it will throw an [TypeError]
   ///
   /// - If animated is true, CarPlay animates the presentation of the template, but will be ignored
   /// this flag when there isn’t an existing navigation hierarchy to replace.
@@ -193,8 +194,7 @@ class FlutterCarplay {
         rootTemplate is CPGridTemplate ||
         rootTemplate is CPListTemplate ||
         rootTemplate is CPInformationTemplate ||
-        rootTemplate is CPPointOfInterestTemplate ||
-        rootTemplate is CPSearchTemplate) {
+        rootTemplate is CPPointOfInterestTemplate) {
       return FlutterCarPlayController.flutterToNativeModule(
           FCPChannelTypes.setRootTemplate, <String, dynamic>{
         'rootTemplate': rootTemplate.toJson(),
@@ -208,6 +208,8 @@ class FlutterCarplay {
           }
         }
       });
+    } else {
+      throw TypeError();
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_carplay
 description: Flutter Apps are now on Apple CarPlay and Android Auto. This package aims to make it safe to use apps made with Flutter in the car by integrating with CarPlay or Android Auto.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/oguzhnatly/flutter_carplay#readme
 repository: https://github.com/oguzhnatly/flutter_carplay
 issue_tracker: https://github.com/oguzhnatly/flutter_carplay/issues

--- a/test/carplay_root_template_test.dart
+++ b/test/carplay_root_template_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_carplay/flutter_carplay.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _carplayChannel = MethodChannel('com.oguzhnatly.flutter_carplay');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(_carplayChannel, null);
+  });
+
+  test('rejects CPSearchTemplate as a root template before native call',
+      () async {
+    var invokedNative = false;
+    messenger.setMockMethodCallHandler(_carplayChannel, (call) async {
+      invokedNative = true;
+      return true;
+    });
+
+    await expectLater(
+      FlutterCarplay.setRootTemplate(rootTemplate: CPSearchTemplate()),
+      throwsA(isA<TypeError>()),
+    );
+
+    expect(invokedNative, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #123 by publishing the SwiftPM search template source path fix from #124.

Also rejects unsupported `CPSearchTemplate` root templates before CarPlay receives an invalid root.

## Verification

`dart format --output=none --set-exit-if-changed lib test`

`flutter analyze`

`flutter test`

`flutter build ios --simulator --debug`

SwiftPM package resolve probe

`flutter pub publish --dry-run`
