### PR TITLE
Fix Android Auto example launch crash

### DIFF
--- a/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FlutterAndroidAutoPlugin.kt
+++ b/android/src/main/kotlin/com/oguzhnatly/flutter_android_auto/FlutterAndroidAutoPlugin.kt
@@ -110,10 +110,8 @@ class FlutterAndroidAutoPlugin : FlutterPlugin, EventChannel.StreamHandler {
     }
 
     private fun forceUpdateRootTemplate(call: MethodCall, result: MethodChannel.Result) {
-        currentScreen?.let {
-            it.invalidate()
-            result.success(true)
-        } ?: result.error("No screen found", "You must set a RootTemplate first", null)
+        currentScreen?.invalidate()
+        result.success(true)
     }
 
     private fun popTemplate(call: MethodCall, result: MethodChannel.Result) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -320,6 +320,14 @@ class _MyAppState extends State<MyApp> {
                 },
               ),
               AAListItem(
+                title: 'Selectable List',
+                subtitle: 'Open Android Auto radio options',
+                onPress: (complete, AAListItem item) {
+                  openAndroidAutoSelectableListTemplate();
+                  complete();
+                },
+              ),
+              AAListItem(
                 title: 'SVG Examples',
                 subtitle: 'Open Android Auto rows backed by SVG assets',
                 imageUrl: 'images/svg_navigation.svg',
@@ -348,17 +356,6 @@ class _MyAppState extends State<MyApp> {
                   complete();
                 },
               ),
-            ],
-          ),
-          AAListSection(
-            title: 'Second Section',
-            selectedIndex: 0,
-            onSelected: (selectedIndex, selectedItem) {
-              print('Selected index: $selectedIndex (${selectedItem.title})');
-            },
-            items: [
-              AAListItem(title: 'Radio option 1'),
-              AAListItem(title: 'Radio option 2'),
             ],
           ),
           AAListSection(
@@ -400,6 +397,26 @@ class _MyAppState extends State<MyApp> {
       ),
     );
     _flutterAndroidAuto.forceUpdateRootTemplate();
+  }
+
+  void openAndroidAutoSelectableListTemplate() {
+    FlutterAndroidAuto.push(
+      template: AAListTemplate(
+        title: 'Selectable List',
+        sections: [
+          AAListSection(
+            selectedIndex: 0,
+            onSelected: (selectedIndex, selectedItem) {
+              print('Selected index: $selectedIndex (${selectedItem.title})');
+            },
+            items: [
+              AAListItem(title: 'Radio option 1'),
+              AAListItem(title: 'Radio option 2'),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   void openAndroidAutoMessageTemplate() {

--- a/lib/aa_models/list/list_section.dart
+++ b/lib/aa_models/list/list_section.dart
@@ -42,6 +42,8 @@ class AAListSection {
 
   String get uniqueId => _elementId;
 
+  bool get isSelectable => selectedIndex != null || onSelected != null;
+
   Map<String, dynamic> toJson() => {
         '_elementId': _elementId,
         'title': title,

--- a/lib/aa_models/list/list_template.dart
+++ b/lib/aa_models/list/list_template.dart
@@ -40,7 +40,12 @@ class AAListTemplate implements AATemplate {
     this.systemIcon,
     this.iconUrl,
     String? id,
-  }) : _elementId = id ?? const Uuid().v4();
+  })  : assert(
+          !sections.any((section) => section.isSelectable) ||
+              sections.length == 1,
+          'Android Auto selectable list sections cannot be mixed with other sections.',
+        ),
+        _elementId = id ?? const Uuid().v4();
 
   @override
   String get uniqueId => _elementId;

--- a/test/aa_models/list_template_test.dart
+++ b/test/aa_models/list_template_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_carplay/flutter_carplay.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AAListTemplate', () {
+    test('allows a single selectable section', () {
+      final template = AAListTemplate(
+        title: 'Audio source',
+        sections: [
+          AAListSection(
+            selectedIndex: 0,
+            onSelected: (_, __) {},
+            items: [
+              AAListItem(title: 'Radio option 1'),
+              AAListItem(title: 'Radio option 2'),
+            ],
+          ),
+        ],
+      );
+
+      expect(template.sections.single.selectedIndex, 0);
+    });
+
+    test('rejects selectable sections mixed with other sections', () {
+      expect(
+        () => AAListTemplate(
+          title: 'Home',
+          sections: [
+            AAListSection(
+              title: 'Pages',
+              items: [AAListItem(title: 'Page 1')],
+            ),
+            AAListSection(
+              title: 'Radio options',
+              selectedIndex: 0,
+              onSelected: (_, __) {},
+              items: [
+                AAListItem(title: 'Radio option 1'),
+                AAListItem(title: 'Radio option 2'),
+              ],
+            ),
+          ],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Summary

Fixes the Android Auto example launch crash by making root template refresh safe before a car screen is attached. Also moves the selectable list demo into its own template, because Android Auto does not allow selectable lists alongside other list sections.

Verification

flutter analyze passed.
flutter test passed.
flutter build apk release mode passed.
Release APK launched on an Android emulator. Logcat showed no No screen found, PlatformException, fatal exception, or selectable list crash.

Fixes #127
